### PR TITLE
fix(ci): repair the pipeline and make the format gate unskippable

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -3,32 +3,138 @@ name: CI Backend
 on:
   push:
     branches: [main, dev]
-    paths: ["back/**", ".github/workflows/ci-backend.yml"]
+    paths:
+      - "back/**"
+      - ".github/workflows/ci-backend.yml"
   pull_request:
-    paths: ["back/**", ".github/workflows/ci-backend.yml"]
+    paths:
+      - "back/**"
+      - ".github/workflows/ci-backend.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A newer push to the same ref makes the in-flight run pointless.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned to the version baked into back/build/Dockerfile.api so CI and the
+  # image resolve dependencies identically.
+  UV_VERSION: "0.12.3"
 
 jobs:
-  lint-test:
+  lint:
+    name: Lint & format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: back
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
+          cache-dependency-glob: back/uv.lock
 
       - name: Install dependencies
         run: uv sync --frozen
 
       - name: Ruff lint
-        run: uv run ruff check .
+        run: uv run ruff check --output-format=github .
 
+      # Kept in the same gate as the linter: `ruff check` does not enforce
+      # formatting, so without this the tree drifts until a release run fails.
       - name: Ruff format check
-        run: uv run ruff format --check .
+        run: uv run ruff format --check --diff .
+
+  test:
+    name: Tests (unit + integration)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: back
+
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.0-pg16
+        env:
+          POSTGRES_USER: nodum
+          POSTGRES_PASSWORD: nodum
+          POSTGRES_DB: nodum
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U nodum" --health-interval 5s
+          --health-timeout 5s --health-retries 20
+
+      redis:
+        image: redis:7.4.2-alpine
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 5s
+          --health-timeout 5s --health-retries 20
+
+    env:
+      ENVIRONMENT: test
+      POSTGRES_SERVER: localhost
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: nodum
+      POSTGRES_PASSWORD: nodum
+      POSTGRES_DB: nodum
+      REDIS_URL: redis://localhost:6379/0
+      S3_ENDPOINT_URL: http://localhost:9000
+      S3_PUBLIC_URL: http://localhost:9000
+      S3_ACCESS_KEY: minioadmin
+      S3_SECRET_KEY: minioadmin
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # MinIO cannot be a `services:` container: its image needs the `server
+      # /data` command, and service containers cannot override CMD. Same image
+      # and args as deploy/docker-compose.yml so CI matches the real stack.
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+          for _ in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              echo "MinIO ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::MinIO never became ready"; docker logs minio; exit 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: back/uv.lock
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run migrations
+        run: uv run alembic upgrade head
 
       - name: Unit tests
         run: uv run pytest tests/unit -q
+
+      # These exercise the real Postgres/Redis/S3 stack and had never run in
+      # CI — every ownership, publish-token and rotation guarantee lives here.
+      - name: Integration tests
+        run: uv run pytest tests/integration -q
+
+      - name: Service logs on failure
+        if: failure()
+        run: docker logs minio || true

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -124,6 +124,16 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
+      # Without this the server refuses to store provider keys and 12 AI tests
+      # fail. Generated per run rather than committed: a real Fernet key
+      # exercises the primary crypto path (not the passphrase-stretch
+      # fallback), and nothing secret-shaped ends up in the repo.
+      - name: Generate ephemeral AI encryption key
+        run: |
+          KEY=$(uv run python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')
+          echo "::add-mask::$KEY"
+          echo "AI_ENCRYPTION_KEY=$KEY" >> "$GITHUB_ENV"
+
       - name: Run migrations
         run: uv run alembic upgrade head
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -4,10 +4,24 @@ on:
   push:
     branches: [main, dev]
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UV_VERSION: "0.12.3"
 
 jobs:
   e2e:
+    name: Playwright (full stack)
     runs-on: ubuntu-latest
+    timeout-minutes: 40
+
     services:
       postgres:
         image: pgvector/pgvector:0.8.0-pg16
@@ -18,33 +32,48 @@ jobs:
         ports: ["5432:5432"]
         options: >-
           --health-cmd "pg_isready -U nodum" --health-interval 5s
-          --health-timeout 5s --health-retries 10
+          --health-timeout 5s --health-retries 20
+
       redis:
         image: redis:7.4.2-alpine
         ports: ["6379:6379"]
         options: >-
           --health-cmd "redis-cli ping" --health-interval 5s
-          --health-timeout 5s --health-retries 10
-      minio:
-        image: bitnami/minio:2025.9.7
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        ports: ["9000:9000"]
+          --health-timeout 5s --health-retries 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+
+      # NOT a `services:` container: the official MinIO image needs the
+      # `server /data` command and service containers cannot set one. The
+      # previous bitnami/minio:2025.9.7 pin was deleted from the public Docker
+      # Hub catalogue, which failed every run at container-init time.
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+          for _ in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              echo "MinIO ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::MinIO never became ready"; docker logs minio; exit 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
+          cache-dependency-glob: back/uv.lock
 
       - name: Install backend deps
         working-directory: back
         run: uv sync --frozen
 
-      - name: Start API
+      - name: Migrate and start API
         working-directory: back
         env:
           ENVIRONMENT: dev
@@ -55,10 +84,16 @@ jobs:
           S3_PUBLIC_URL: http://localhost:9000
         run: |
           uv run alembic upgrade head
-          nohup uv run uvicorn app.main:app --host 127.0.0.1 --port 8000 &
-          for i in $(seq 1 30); do curl -sf http://127.0.0.1:8000/health && break || sleep 1; done
+          nohup uv run uvicorn app.main:app --host 127.0.0.1 --port 8000 > api.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8000/health >/dev/null; then
+              echo "API ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::API never became ready"; cat api.log; exit 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -68,18 +103,45 @@ jobs:
         working-directory: web
         run: npm ci
 
-      - name: Build and start web
+      - name: Resolve Playwright version
+        id: pw
         working-directory: web
-        env:
-          API_PROXY_URL: http://127.0.0.1:8000
-        run: |
-          npm run build
-          nohup npx next start -p 3100 &
-          for i in $(seq 1 30); do curl -sf http://127.0.0.1:3100 >/dev/null && break || sleep 1; done
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
 
       - name: Install Playwright browsers
         working-directory: web
         run: npx playwright install --with-deps chromium
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+
+      # Cache restores the browser binaries but not the apt libraries they
+      # link against, so system deps still have to be installed on a hit.
+      - name: Install Playwright system deps
+        working-directory: web
+        run: npx playwright install-deps chromium
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+
+      - name: Build and start web
+        working-directory: web
+        env:
+          API_PROXY_URL: http://127.0.0.1:8000
+          NEXT_TELEMETRY_DISABLED: "1"
+        run: |
+          npm run build
+          nohup npx next start -p 3100 > web.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:3100 >/dev/null; then
+              echo "Web ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Web never became ready"; cat web.log; exit 1
 
       - name: Run e2e suite
         working-directory: web
@@ -87,10 +149,31 @@ jobs:
           BASE_URL: http://127.0.0.1:3100
         run: npx playwright test
 
-      - name: Upload traces on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
+      # `if: always()` (not `failure()`): a cancelled or early-failing job
+      # still uploads whatever exists, and `ignore` stops the upload step
+      # itself from erroring when the run died before producing anything.
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
         with:
-          name: playwright-traces
-          path: web/test-results/
+          name: playwright-report-${{ github.run_id }}
+          path: |
+            web/playwright-report/
+            web/test-results/
           retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-logs-${{ github.run_id }}
+          path: |
+            back/api.log
+            web/web.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: MinIO logs on failure
+        if: failure()
+        run: docker logs minio || true

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -73,6 +73,16 @@ jobs:
         working-directory: back
         run: uv sync --frozen
 
+      # Without this the API refuses to store provider keys, so every AI e2e
+      # spec fails deterministically — and burns all `retries: 2` doing it.
+      # Generated per run so nothing secret-shaped is committed.
+      - name: Generate ephemeral AI encryption key
+        working-directory: back
+        run: |
+          KEY=$(uv run python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')
+          echo "::add-mask::$KEY"
+          echo "AI_ENCRYPTION_KEY=$KEY" >> "$GITHUB_ENV"
+
       - name: Migrate and start API
         working-directory: back
         env:

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -3,27 +3,47 @@ name: CI Web
 on:
   push:
     branches: [main, dev]
-    paths: ["web/**", ".github/workflows/ci-web.yml"]
+    paths:
+      - "web/**"
+      - ".github/workflows/ci-web.yml"
   pull_request:
-    paths: ["web/**", ".github/workflows/ci-web.yml"]
+    paths:
+      - "web/**"
+      - ".github/workflows/ci-web.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint-build:
+    name: Lint, typecheck & build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
+          # Matches web/docker/Dockerfile (node:22-alpine).
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
         run: npm ci
+
+      # Explicit and first: a type error surfaces in seconds here instead of
+      # four minutes into `next build`.
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Lint
         run: npm run lint
@@ -32,3 +52,4 @@ jobs:
         run: npm run build
         env:
           NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
+          NEXT_TELEMETRY_DISABLED: "1"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,17 +4,40 @@ on:
   push:
     branches: [main, dev]
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITLEAKS_VERSION: "8.30.1"
 
 jobs:
   gitleaks:
+    name: Gitleaks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
+          # Full history: a secret is still a secret after the commit that
+          # removed it.
           fetch-depth: 0
 
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+      # The gitleaks CLI rather than gitleaks-action: the action needs a paid
+      # licence key for org-owned repos, and it calls the PR-commits API, which
+      # 403s unless the job is granted pull-requests:read. The binary needs
+      # neither and behaves identically on push and pull_request.
+      - name: Install gitleaks
+        run: |
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan git history
+        run: gitleaks git . --config .gitleaks.toml --redact --verbose --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+# Gitleaks configuration — see .github/workflows/secret-scan.yml
+#
+# Start from the full upstream ruleset and only ever subtract from it with a
+# narrowly scoped allowlist. Never widen a rule: a false positive is cheap,
+# a missed credential in a public repo is not.
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = """
+`s3_key = attachment.s3_key` — an ORM attribute read, not a credential. The
+generic-api-key rule fires on the `key =` shape. Scoped to that one expression
+in that one file, so a real secret assigned anywhere else here is still caught.
+This has to live in config rather than an inline `# gitleaks:allow` comment
+because the scan walks git history, where older revisions carry no comment.
+"""
+condition = "AND"
+paths = ['''back/app/services/attachment_service\.py''']
+regexTarget = "match"
+regexes = ['''s3_key\s*=\s*attachment\.s3_key''']

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,15 +22,18 @@ truth for project state, architecture, and what to build next. Update it
   placeholders. This repo is public.
 - Backend: routers thin / services fat (`ServiceResponse.unwrap()` pattern);
   responses `{"data": ...}`, errors `{"error": {"code","message"}}`;
-  numbered alembic migrations (`0001_...`); `uv run pytest tests/unit` and
-  `uv run ruff check .` must pass before commit.
+  numbered alembic migrations (`0001_...`); **`make verify` must pass before
+  commit** — it runs the exact gate CI runs. `ruff check` alone is not enough:
+  CI also runs `ruff format --check`, and skipping it is what silently rotted
+  the pipeline before.
 - All compose host ports bind to `127.0.0.1`. Containers run non-root in prod.
 - Frontend: workspace state in Zustand, server data via TanStack Query;
   API access only through `src/lib/api/`.
 
 ## Commands
 
+- `make verify` — the full pre-push gate (everything CI runs except e2e)
 - `make dev-up` / `make dev-down` — full dev stack via Docker
-- `make back-test back-lint` — backend checks
-- `make web-build web-lint` — web checks
+- `make back-test back-test-int back-lint` — backend checks
+- `make web-typecheck web-lint web-build` — web checks
 - `make e2e` — Playwright suite

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # Nodum — Development Makefile
 # ============================================================
 
-.PHONY: help dev-up dev-down dev-logs test-up test-down back-test back-lint back-format web-dev web-build web-lint e2e
+.PHONY: help dev-up dev-down dev-logs test-up test-down back-test back-test-int back-lint back-format \
+        web-dev web-build web-lint web-typecheck e2e verify
 
 help:            ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
@@ -27,7 +28,10 @@ test-down:       ## Stop test stack
 back-test:       ## Run backend unit tests
 	cd back && uv run pytest tests/unit -q
 
-back-lint:       ## Lint backend
+back-test-int:   ## Run backend integration tests (needs infra up)
+	cd back && uv run pytest tests/integration -q
+
+back-lint:       ## Lint backend (check + format check — same gate as CI)
 	cd back && uv run ruff check . && uv run ruff format --check .
 
 back-format:     ## Format backend
@@ -43,8 +47,19 @@ web-build:       ## Production build of the web app
 web-lint:        ## Lint web
 	cd web && npm run lint
 
+web-typecheck:   ## Typecheck web (tsc --noEmit)
+	cd web && npm run typecheck
+
 e2e:             ## Run Playwright e2e suite (needs test stack up)
 	cd web && npx playwright test
+
+# ── Gates ───────────────────────────────────────────────────
+verify:          ## Everything CI runs, minus e2e — run before you push
+	$(MAKE) back-lint
+	$(MAKE) back-test
+	$(MAKE) web-typecheck
+	$(MAKE) web-lint
+	$(MAKE) web-build
 
 
 # ── Utilities ─────────────────────────────────────────────────────

--- a/back/app/api/v1/ai.py
+++ b/back/app/api/v1/ai.py
@@ -52,7 +52,6 @@ class RenameConversationRequest(BaseModel):
     title: str = Field(max_length=200)
 
 
-
 @router.get("/status")
 async def ai_status(user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
     """Which providers this user has configured — never the keys themselves."""
@@ -60,9 +59,7 @@ async def ai_status(user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
 
 
 @router.put("/credentials")
-async def save_credential(
-    body: CredentialRequest, user_id: CurrentUserId, db: SessionDep
-) -> dict[str, Any]:
+async def save_credential(body: CredentialRequest, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
     data = (
         await ai_service.save_credential(
             db,
@@ -110,9 +107,7 @@ async def rename_conversation(
     user_id: CurrentUserId,
     db: SessionDep,
 ) -> dict[str, Any]:
-    data = (
-        await ai_service.rename_conversation(db, user_id, vault_id, conversation_id, body.title)
-    ).unwrap()
+    data = (await ai_service.rename_conversation(db, user_id, vault_id, conversation_id, body.title)).unwrap()
     return {"data": data}
 
 

--- a/back/app/api/v1/notes.py
+++ b/back/app/api/v1/notes.py
@@ -65,9 +65,7 @@ async def update_note_content(
 async def update_note_tags(
     vault_id: UUID, note_id: UUID, body: NoteTagsRequest, user_id: CurrentUserId, db: SessionDep
 ) -> dict[str, Any]:
-    note = (
-        await note_service.set_tags(db, vault_id, user_id, note_id, add=body.add, remove=body.remove)
-    ).unwrap()
+    note = (await note_service.set_tags(db, vault_id, user_id, note_id, add=body.add, remove=body.remove)).unwrap()
     return {"data": NoteOut.model_validate(note).model_dump()}
 
 

--- a/back/app/api/v1/vault_io.py
+++ b/back/app/api/v1/vault_io.py
@@ -67,7 +67,5 @@ async def import_files(
                 continue
             zf.writestr(name, content)
 
-    stats = (
-        await vault_io_service.import_zip(db, vault_id, user_id, archive=buffer.getvalue())
-    ).unwrap()
+    stats = (await vault_io_service.import_zip(db, vault_id, user_id, archive=buffer.getvalue())).unwrap()
     return {"data": stats}

--- a/back/app/models/ai/conversation.py
+++ b/back/app/models/ai/conversation.py
@@ -56,13 +56,9 @@ class AIMessage(UUIDMixin, Base):
     )
     role: Mapped[str] = mapped_column(String(16), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False, default="")
-    actions: Mapped[list[dict[str, Any]]] = mapped_column(
-        JSONB, nullable=False, default=list, server_default="[]"
-    )
+    actions: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False, default=list, server_default="[]")
     # Messages are append-only, so there is nothing for an updated_at to say.
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), nullable=False
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     __table_args__ = (Index("ix_ai_messages_conversation", "conversation_id", "created_at"),)
 

--- a/back/app/services/ai_providers.py
+++ b/back/app/services/ai_providers.py
@@ -121,16 +121,12 @@ class Turn:
 def _tools_for(provider: str, tools: list[dict[str, Any]]) -> Any:
     """Translate our neutral tool declarations into the provider's shape."""
     if provider == "anthropic":
-        return [
-            {"name": t["name"], "description": t["description"], "input_schema": t["parameters"]}
-            for t in tools
-        ]
+        return [{"name": t["name"], "description": t["description"], "input_schema": t["parameters"]} for t in tools]
     if provider == "gemini":
         return [
             {
                 "functionDeclarations": [
-                    {"name": t["name"], "description": t["description"], "parameters": t["parameters"]}
-                    for t in tools
+                    {"name": t["name"], "description": t["description"], "parameters": t["parameters"]} for t in tools
                 ]
             }
         ]

--- a/back/app/services/ai_service.py
+++ b/back/app/services/ai_service.py
@@ -278,9 +278,7 @@ async def get_conversation(
             "id": str(conversation.id),
             "title": conversation.title,
             "updated_at": conversation.updated_at.isoformat(),
-            "messages": [
-                {"role": m.role, "content": m.content, "actions": m.actions or []} for m in messages
-            ],
+            "messages": [{"role": m.role, "content": m.content, "actions": m.actions or []} for m in messages],
         }
     )
 
@@ -392,10 +390,9 @@ async def chat_with_vault(
         if found is None:
             return ServiceResponse.fail("not_found", "Conversation not found.")
         conversation = found
-        prior = [
-            {"role": m.role, "content": m.content}
-            for m in await _conversation_messages(db, conversation.id)
-        ][-MAX_MESSAGES:]
+        prior = [{"role": m.role, "content": m.content} for m in await _conversation_messages(db, conversation.id)][
+            -MAX_MESSAGES:
+        ]
 
     messages = [*prior, {"role": "user", "content": message}]
 
@@ -464,9 +461,7 @@ async def chat_with_vault(
         return ServiceResponse.fail("validation_failed", "Could not reach the provider.")
 
     db.add(AIMessage(conversation_id=conversation.id, role="user", content=message))
-    db.add(
-        AIMessage(conversation_id=conversation.id, role="assistant", content=reply, actions=actions)
-    )
+    db.add(AIMessage(conversation_id=conversation.id, role="assistant", content=reply, actions=actions))
     # Touch the thread so the history list sorts by real activity. (The tools
     # may have committed mid-turn, which leaves updated_at stale otherwise.)
     conversation.updated_at = datetime.now(UTC)

--- a/back/app/services/ai_tools.py
+++ b/back/app/services/ai_tools.py
@@ -110,9 +110,7 @@ async def run_tool(
     because a tool failure is something the model should see and recover from."""
     try:
         if name == "search_notes":
-            found = await search_service.search_notes(
-                db, vault_id, user_id, q=str(args.get("query", "")), limit=8
-            )
+            found = await search_service.search_notes(db, vault_id, user_id, q=str(args.get("query", "")), limit=8)
             if not found.success:
                 return {"ok": False, "error": found.message}
             return {

--- a/back/app/services/attachment_service.py
+++ b/back/app/services/attachment_service.py
@@ -58,9 +58,23 @@ ALLOWED_ATTACHMENT_TYPES: dict[str, str] = {
 # Types safe to render in a browser tab; everything else downloads instead of
 # being interpreted (defence in depth on top of the allowlist).
 _INLINE_TYPES = {
-    "image/png", "image/jpeg", "image/gif", "image/webp", "image/avif", "image/bmp",
-    "image/x-icon", "application/pdf", "text/plain", "text/markdown", "text/csv",
-    "audio/mpeg", "audio/wav", "audio/ogg", "audio/mp4", "video/mp4", "video/webm",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/avif",
+    "image/bmp",
+    "image/x-icon",
+    "application/pdf",
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "audio/mpeg",
+    "audio/wav",
+    "audio/ogg",
+    "audio/mp4",
+    "video/mp4",
+    "video/webm",
     "video/quicktime",
 }
 

--- a/back/app/services/clipper_service.py
+++ b/back/app/services/clipper_service.py
@@ -126,6 +126,4 @@ async def clip(
     created = await create_note(db, target, user.id, title=clean_title, folder_id=folder_id, content=body)
     if not created.success or created.data is None:
         return ServiceResponse.fail(created.error_code or "validation_failed", created.message or "Clip failed.")
-    return ServiceResponse.ok(
-        {"id": str(created.data.id), "title": created.data.title, "vault_id": str(target)}
-    )
+    return ServiceResponse.ok({"id": str(created.data.id), "title": created.data.title, "vault_id": str(target)})

--- a/back/app/services/folder_service.py
+++ b/back/app/services/folder_service.py
@@ -23,9 +23,7 @@ async def _path_taken(db: AsyncSession, vault_id: UUID, path: str, *, exclude_id
     return (await db.scalar(q)) is not None
 
 
-async def ensure_folder_path(
-    db: AsyncSession, vault_id: UUID, user_id: UUID, path: str
-) -> UUID | None:
+async def ensure_folder_path(db: AsyncSession, vault_id: UUID, user_id: UUID, path: str) -> UUID | None:
     """Get or create the (possibly nested) folder for a slash path; None = root."""
     path = path.strip().strip("/")
     if not path:
@@ -37,9 +35,7 @@ async def ensure_folder_path(
         if not segment:
             continue
         walked = f"{walked}/{segment}" if walked else segment
-        existing = await db.scalar(
-            select(Folder).where(Folder.vault_id == vault_id, Folder.path == walked)
-        )
+        existing = await db.scalar(select(Folder).where(Folder.vault_id == vault_id, Folder.path == walked))
         if existing:
             parent_id = existing.id
             continue

--- a/back/tests/integration/test_ai_conversations.py
+++ b/back/tests/integration/test_ai_conversations.py
@@ -35,7 +35,8 @@ async def account(client: AsyncClient) -> dict:
     tokens = await _signup(client, "aiconv")
     await client.put(
         "/api/v1/ai/credentials",
-        json={"provider": "openai", "api_key": "sk-stub-conv", "model": "stub"},
+        # Not "sk-…": a vendor-shaped prefix trips secret scanners on every diff.
+        json={"provider": "openai", "api_key": "fake-stub-conv-key", "model": "stub"},
         headers=_auth(tokens),
     )
     vaults = await client.get("/api/v1/vaults", headers=_auth(tokens))

--- a/back/tests/integration/test_ai_conversations.py
+++ b/back/tests/integration/test_ai_conversations.py
@@ -73,9 +73,7 @@ async def test_a_turn_creates_a_conversation_titled_after_the_question(
     listed = await client.get(f"/api/v1/ai/vaults/{vault}/conversations", headers=headers)
     assert [c["id"] for c in listed.json()["data"]] == [data["conversation_id"]]
 
-    full = await client.get(
-        f"/api/v1/ai/vaults/{vault}/conversations/{data['conversation_id']}", headers=headers
-    )
+    full = await client.get(f"/api/v1/ai/vaults/{vault}/conversations/{data['conversation_id']}", headers=headers)
     messages = full.json()["data"]["messages"]
     assert [(m["role"], m["content"]) for m in messages] == [
         ("user", "What is spaced repetition?"),
@@ -88,9 +86,7 @@ async def test_the_stored_history_is_what_the_provider_sees_next_turn(
 ) -> None:
     headers = _auth(account["tokens"])
     vault = account["vault_id"]
-    first = await client.post(
-        f"/api/v1/ai/vaults/{vault}/chat", json={"message": "first"}, headers=headers
-    )
+    first = await client.post(f"/api/v1/ai/vaults/{vault}/chat", json={"message": "first"}, headers=headers)
     conversation_id = first.json()["data"]["conversation_id"]
 
     await client.post(
@@ -102,28 +98,18 @@ async def test_the_stored_history_is_what_the_provider_sees_next_turn(
     second_call = stub_provider[1]
     assert [m["content"] for m in second_call] == ["first", "stub reply", "second"]
 
-    full = await client.get(
-        f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=headers
-    )
+    full = await client.get(f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=headers)
     assert len(full.json()["data"]["messages"]) == 4
 
 
-async def test_a_second_chat_is_a_separate_thread(
-    client: AsyncClient, account: dict, stub_provider: list
-) -> None:
+async def test_a_second_chat_is_a_separate_thread(client: AsyncClient, account: dict, stub_provider: list) -> None:
     headers = _auth(account["tokens"])
     vault = account["vault_id"]
-    one = await client.post(
-        f"/api/v1/ai/vaults/{vault}/chat", json={"message": "alpha"}, headers=headers
-    )
-    two = await client.post(
-        f"/api/v1/ai/vaults/{vault}/chat", json={"message": "beta"}, headers=headers
-    )
+    one = await client.post(f"/api/v1/ai/vaults/{vault}/chat", json={"message": "alpha"}, headers=headers)
+    two = await client.post(f"/api/v1/ai/vaults/{vault}/chat", json={"message": "beta"}, headers=headers)
     assert one.json()["data"]["conversation_id"] != two.json()["data"]["conversation_id"]
 
-    listed = (await client.get(f"/api/v1/ai/vaults/{vault}/conversations", headers=headers)).json()[
-        "data"
-    ]
+    listed = (await client.get(f"/api/v1/ai/vaults/{vault}/conversations", headers=headers)).json()["data"]
     # Most recent first.
     assert [c["title"] for c in listed] == ["beta", "alpha"]
 
@@ -131,9 +117,7 @@ async def test_a_second_chat_is_a_separate_thread(
 async def test_rename_and_delete(client: AsyncClient, account: dict, stub_provider: list) -> None:
     headers = _auth(account["tokens"])
     vault = account["vault_id"]
-    created = await client.post(
-        f"/api/v1/ai/vaults/{vault}/chat", json={"message": "throwaway"}, headers=headers
-    )
+    created = await client.post(f"/api/v1/ai/vaults/{vault}/chat", json={"message": "throwaway"}, headers=headers)
     conversation_id = created.json()["data"]["conversation_id"]
 
     renamed = await client.patch(
@@ -143,16 +127,12 @@ async def test_rename_and_delete(client: AsyncClient, account: dict, stub_provid
     )
     assert renamed.json()["data"]["title"] == "Reading list"
 
-    removed = await client.delete(
-        f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=headers
-    )
+    removed = await client.delete(f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=headers)
     assert removed.status_code == 200
     listed = await client.get(f"/api/v1/ai/vaults/{vault}/conversations", headers=headers)
     assert listed.json()["data"] == []
     # And the messages went with it.
-    gone = await client.get(
-        f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=headers
-    )
+    gone = await client.get(f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=headers)
     assert gone.status_code == 404
 
 
@@ -161,9 +141,7 @@ async def test_history_belongs_to_its_vault_and_its_owner(
 ) -> None:
     headers = _auth(account["tokens"])
     vault = account["vault_id"]
-    created = await client.post(
-        f"/api/v1/ai/vaults/{vault}/chat", json={"message": "private"}, headers=headers
-    )
+    created = await client.post(f"/api/v1/ai/vaults/{vault}/chat", json={"message": "private"}, headers=headers)
     conversation_id = created.json()["data"]["conversation_id"]
 
     # Another vault of the SAME user must not answer for it: the assistant's
@@ -172,21 +150,15 @@ async def test_history_belongs_to_its_vault_and_its_owner(
         await client.post("/api/v1/vaults", json={"name": f"Other {uuid.uuid4().hex[:6]}"}, headers=headers)
     ).json()["data"]["id"]
     assert (
-        await client.get(
-            f"/api/v1/ai/vaults/{other_vault}/conversations/{conversation_id}", headers=headers
-        )
+        await client.get(f"/api/v1/ai/vaults/{other_vault}/conversations/{conversation_id}", headers=headers)
     ).status_code == 404
-    assert (
-        await client.get(f"/api/v1/ai/vaults/{other_vault}/conversations", headers=headers)
-    ).json()["data"] == []
+    assert (await client.get(f"/api/v1/ai/vaults/{other_vault}/conversations", headers=headers)).json()["data"] == []
 
     # And another user sees nothing at all.
     stranger = _auth(await _signup(client, "aiconv-other"))
     assert (await client.get(f"/api/v1/ai/vaults/{vault}/conversations", headers=stranger)).status_code == 404
     assert (
-        await client.get(
-            f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=stranger
-        )
+        await client.get(f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=stranger)
     ).status_code == 404
 
 
@@ -198,9 +170,7 @@ async def test_a_failed_turn_stores_nothing(client: AsyncClient, account: dict, 
         raise ai_providers.ProviderError("nope")
 
     monkeypatch.setattr(ai_providers, "turn", failing_turn)
-    resp = await client.post(
-        f"/api/v1/ai/vaults/{vault}/chat", json={"message": "will fail"}, headers=headers
-    )
+    resp = await client.post(f"/api/v1/ai/vaults/{vault}/chat", json={"message": "will fail"}, headers=headers)
     assert resp.status_code == 422
     # No half-written thread left behind.
     listed = await client.get(f"/api/v1/ai/vaults/{vault}/conversations", headers=headers)
@@ -218,9 +188,7 @@ async def test_context_only_matters_for_the_prompt_not_the_transcript(
         headers=headers,
     )
     conversation_id = created.json()["data"]["conversation_id"]
-    full = await client.get(
-        f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=headers
-    )
+    full = await client.get(f"/api/v1/ai/vaults/{vault}/conversations/{conversation_id}", headers=headers)
     stored = full.json()["data"]["messages"]
     # The note excerpt rode along in the system prompt; storing it would make
     # the saved thread balloon and go stale.
@@ -232,9 +200,7 @@ async def test_long_conversations_are_capped_when_sent_to_the_provider(
 ) -> None:
     headers = _auth(account["tokens"])
     vault = account["vault_id"]
-    resp = await client.post(
-        f"/api/v1/ai/vaults/{vault}/chat", json={"message": "start"}, headers=headers
-    )
+    resp = await client.post(f"/api/v1/ai/vaults/{vault}/chat", json={"message": "start"}, headers=headers)
     conversation_id = resp.json()["data"]["conversation_id"]
     for i in range(int(ai_service.MAX_MESSAGES / 2) + 2):
         await client.post(

--- a/back/tests/integration/test_ai_credentials.py
+++ b/back/tests/integration/test_ai_credentials.py
@@ -15,7 +15,11 @@ from sqlalchemy import select
 from app.core.db import async_session_factory
 from app.models.ai import AICredential
 
-SECRET_KEY_VALUE = "sk-ant-test-DO-NOT-ECHO-4f2b9c"
+# Deliberately NOT shaped like a real provider key ("sk-ant-…"): secret
+# scanners flag the vendor prefix on every diff that touches this file, and a
+# permanently-failing scanner is worse than no scanner. Nothing validates the
+# format, and the assertions only rely on the value and its last four chars.
+SECRET_KEY_VALUE = "fake-provider-key-DO-NOT-ECHO-4f2b9c"
 
 
 async def _signup(client: AsyncClient, prefix: str) -> dict:
@@ -65,8 +69,10 @@ async def test_the_key_is_stored_encrypted_and_never_returned(client: AsyncClien
     assert body["active_provider"] == "anthropic"
     assert body["active_model"] == "claude-sonnet-4-5"
     assert SECRET_KEY_VALUE not in status.text
-    # A hint, not the key: enough to recognise which key is stored.
-    assert body["credentials"][0]["key_hint"] == "sk-ant…2b9c"
+    # A hint, not the key: enough to recognise which key is stored. Derived
+    # from the fixture rather than hardcoded so it cannot rot if the value
+    # changes — the shape (first 6, ellipsis, last 4) is what matters.
+    assert body["credentials"][0]["key_hint"] == f"{SECRET_KEY_VALUE[:6]}…{SECRET_KEY_VALUE[-4:]}"
 
     # The auth endpoints serialize users.settings in full — the key must not be
     # anywhere in there either.

--- a/back/tests/integration/test_ai_credentials.py
+++ b/back/tests/integration/test_ai_credentials.py
@@ -39,9 +39,7 @@ def _auth(tokens: dict) -> dict:
     return {"Authorization": f"Bearer {tokens['access_token']}"}
 
 
-async def test_status_is_unconfigured_before_anything_is_saved(
-    client: AsyncClient, account: dict
-) -> None:
+async def test_status_is_unconfigured_before_anything_is_saved(client: AsyncClient, account: dict) -> None:
     resp = await client.get("/api/v1/ai/status", headers=_auth(account))
     assert resp.status_code == 200
     data = resp.json()["data"]
@@ -51,9 +49,7 @@ async def test_status_is_unconfigured_before_anything_is_saved(
     assert {p["id"] for p in data["providers"]} == {"anthropic", "openai", "gemini", "qwen"}
 
 
-async def test_the_key_is_stored_encrypted_and_never_returned(
-    client: AsyncClient, account: dict
-) -> None:
+async def test_the_key_is_stored_encrypted_and_never_returned(client: AsyncClient, account: dict) -> None:
     headers = _auth(account)
     saved = await client.put(
         "/api/v1/ai/credentials",
@@ -80,11 +76,7 @@ async def test_the_key_is_stored_encrypted_and_never_returned(
 
     # And the column itself is ciphertext.
     async with async_session_factory() as session:
-        row = (
-            await session.execute(
-                select(AICredential).where(AICredential.provider == "anthropic")
-            )
-        ).scalars().all()
+        row = (await session.execute(select(AICredential).where(AICredential.provider == "anthropic"))).scalars().all()
         stored = [c for c in row if c.key_hint.endswith(SECRET_KEY_VALUE[-4:])]
         assert stored, "credential row not found"
         assert SECRET_KEY_VALUE not in stored[0].key_ciphertext
@@ -110,9 +102,7 @@ async def test_another_user_cannot_see_or_delete_it(client: AsyncClient, account
     assert mine.json()["data"]["configured"] is True
 
 
-async def test_model_can_be_changed_without_re_pasting_the_key(
-    client: AsyncClient, account: dict
-) -> None:
+async def test_model_can_be_changed_without_re_pasting_the_key(client: AsyncClient, account: dict) -> None:
     headers = _auth(account)
     await client.put(
         "/api/v1/ai/credentials",
@@ -164,6 +154,4 @@ async def test_chat_without_a_key_says_so(client: AsyncClient, account: dict) ->
 
 async def test_ai_endpoints_require_authentication(client: AsyncClient) -> None:
     assert (await client.get("/api/v1/ai/status")).status_code == 401
-    assert (
-        await client.put("/api/v1/ai/credentials", json={"provider": "openai", "api_key": "x"})
-    ).status_code == 401
+    assert (await client.put("/api/v1/ai/credentials", json={"provider": "openai", "api_key": "x"})).status_code == 401

--- a/back/tests/integration/test_collab.py
+++ b/back/tests/integration/test_collab.py
@@ -168,9 +168,7 @@ async def test_room_churn_does_not_leak_redis_connections(workspace: dict, runni
         await asyncio.sleep(0.02)
         await collab_server.delete_room(name=name)
 
-    assert len(pool._in_use_connections) - baseline <= 1, (
-        "pubsub connections are not being returned to the pool"
-    )
+    assert len(pool._in_use_connections) - baseline <= 1, "pubsub connections are not being returned to the pool"
     # And the plane is still usable, which is what the leak actually broke.
     await redis_binary.publish(f"collab:{name}", b"\x00" * 33)
 

--- a/back/tests/integration/test_vaults_notes.py
+++ b/back/tests/integration/test_vaults_notes.py
@@ -173,9 +173,7 @@ async def test_folders_and_notes_lifecycle(client: AsyncClient, auth: dict) -> N
     assert "Nodum roadmap" in root_titles
 
 
-async def test_note_create_with_folder_path_creates_missing_folders(
-    client: AsyncClient, auth: dict
-) -> None:
+async def test_note_create_with_folder_path_creates_missing_folders(client: AsyncClient, auth: dict) -> None:
     vaults = (await client.get("/api/v1/vaults", headers=auth)).json()["data"]
     vault_id = vaults[0]["id"]
 

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",


### PR DESCRIPTION
Every **CI E2E** run has been failing at container init, and **CI Backend** was failing on formatting. This fixes all of it and hardens the pipeline.

## Root causes

| Failure | Cause | Fix |
|---|---|---|
| `Docker pull failed with exit code 1` | `bitnami/minio:2025.9.7` was withdrawn from the public Docker Hub catalogue — `manifest unknown` | Start MinIO as a `docker run` step on `minio/minio`, the same image as `deploy/docker-compose.yml`. It can't be a `services:` container — the official image needs a `server /data` command and service containers can't set one |
| `Node.js 20 is deprecated` | Every action a major behind | checkout / setup-node / upload-artifact `v4 → v7`, setup-uv `v5 → v10.0.1` |
| `14 files would be reformatted` | `make back-lint` always ran `ruff format --check`; `CLAUDE.md` documented only `ruff check`, so the tree drifted | Backend reformatted; `CLAUDE.md` now points at a new `make verify` |
| `No files were found with the provided path` | `if: failure()` + bare path, so it errored whenever the job died before Playwright ran | `if: always()` + `if-no-files-found: ignore`; uploads report, results and server logs |
| Secret Scan 403 | gitleaks-action needs a paid licence on org repos and `pull-requests:read` for its PR-commits call | Pinned gitleaks **CLI**, which needs neither |

## Also

- **The 70 backend integration tests never ran in CI.** Every ownership, publish-token and refresh-rotation guarantee lives in them. They now run against real Postgres, Redis and MinIO.
- `permissions:`, `concurrency:` (cancels superseded runs) and `timeout-minutes:` on every job.
- Playwright browser caching; readiness loops that **fail** instead of falling through to a confusing test error.
- Web CI gained a typecheck step; `make verify`, `make back-test-int`, `make web-typecheck`.
- `.gitleaks.toml` allowlists exactly one false positive (`s3_key = attachment.s3_key`, an ORM read the `generic-api-key` rule scores on the `key =` shape). Full history scans clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)