### PR TITLE
CI hardening, image slimming, editor data-loss fix and query performance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+# Dependency updates.
+#
+# Grouped aggressively on purpose: an ungrouped config on a stack this size
+# opens ~20 PRs a week, which trains you to close them unread. One PR per
+# ecosystem per week is a review you actually do.
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: uv
+    directory: "/back"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Patch/minor across the board in one PR; majors get their own so the
+      # breaking one is not buried in a 40-package diff.
+      backend-minor:
+        patterns: ["*"]
+        update-types: [minor, patch]
+    ignore:
+      # kombu 5.6.2 declares `redis<6.5`, so a redis 8.x PR cannot resolve.
+      # Revisit when celery/kombu lifts the cap.
+      - dependency-name: redis
+        versions: [">=6.5"]
+
+  - package-ecosystem: npm
+    directory: "/web"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      web-minor:
+        patterns: ["*"]
+        update-types: [minor, patch]
+    ignore:
+      # eslint-config-next's bundled eslint-plugin-react calls
+      # context.getFilename(), removed in ESLint 10 — v10 crashes on every file
+      # despite the `>=9.0.0` peer range.
+      - dependency-name: eslint
+        versions: [">=10"]
+      # typescript-eslint refuses to load against TS 7 ("does not support TS
+      # 7.0"), which takes linting out entirely.
+      - dependency-name: typescript
+        versions: [">=7"]
+
+  - package-ecosystem: docker
+    directories:
+      - "/back/build"
+      - "/web/docker"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(docker)"

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -92,6 +92,13 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
           S3_ENDPOINT_URL: http://localhost:9000
           S3_PUBLIC_URL: http://localhost:9000
+          # ai-chat.spec.ts points the provider base_url at a stub server on
+          # 127.0.0.1, which the SSRF guard refuses by default — correctly, on
+          # a multi-tenant server. The e2e stack is single-tenant and the stub
+          # is the whole point, so the opt-in is switched on here rather than
+          # weakening the guard. The integration suite still runs with it off,
+          # so the rejection path stays covered.
+          AI_ALLOW_PRIVATE_BASE_URLS: "true"
         run: |
           uv run alembic upgrade head
           nohup uv run uvicorn app.main:app --host 127.0.0.1 --port 8000 > api.log 2>&1 &

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Monday 03:17 UTC. Off the hour on purpose — the top of the hour is when
+    # every scheduled workflow on GitHub queues at once.
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    # Code scanning needs GitHub Advanced Security, which a private repo on a
+    # free plan does not have — the upload step would fail every single run.
+    # This lights up on its own the moment the repo goes public (the stated
+    # intent for an open-source project), and can be forced on beforehand with
+    # a repository variable if Advanced Security is enabled.
+    if: >-
+      github.event.repository.visibility == 'public' ||
+      vars.ENABLE_CODEQL == 'true'
+
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+          - language: javascript-typescript
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended adds the lower-severity rules; worth it on a
+          # multi-tenant app where an IDOR matters more than a lint.
+          queries: security-extended
+          # Neither language needs a build: Python is interpreted and the
+          # TypeScript extractor reads source directly.
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,108 @@
+name: Docker
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "back/**"
+      - "web/**"
+      - "deploy/**"
+      - ".github/workflows/docker.yml"
+  pull_request:
+    paths:
+      - "back/**"
+      - "web/**"
+      - "deploy/**"
+      - ".github/workflows/docker.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-config:
+    name: Validate compose files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # A typo in a compose file is otherwise found by an operator mid-deploy.
+      # Every environment resolves against .env.example, which also proves the
+      # example still carries every variable the files interpolate.
+      - name: Render every environment
+        working-directory: deploy
+        run: |
+          cp .env.example .env
+          for env in dev test prod; do
+            echo "── $env ──"
+            ./compose.sh "$env" config --quiet
+          done
+
+  build-scan:
+    name: Build & scan ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: api
+            context: back
+            dockerfile: back/build/Dockerfile.api
+          - name: web
+            context: web
+            dockerfile: web/docker/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      # The production images were never built in CI, so a broken Dockerfile
+      # only surfaced during a deploy. Loaded into the local daemon rather than
+      # pushed — this validates the build and feeds the scanner, it does not
+      # publish anything.
+      - name: Build production image
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: production
+          load: true
+          tags: nodum-${{ matrix.name }}:ci
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      # ignore-unfixed: base-image CVEs with no upstream patch are not
+      # actionable, and a gate that cannot be made green is a gate everyone
+      # learns to skip. This fails only on something we can actually fix.
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: nodum-${{ matrix.name }}:ci
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Confirm the image does not run as root
+        run: |
+          user=$(docker image inspect nodum-${{ matrix.name }}:ci --format '{{.Config.User}}')
+          echo "USER=${user:-<empty>}"
+          if [ -z "$user" ] || [ "$user" = "root" ] || [ "$user" = "0" ]; then
+            echo "::error::nodum-${{ matrix.name }} production image runs as root"
+            exit 1
+          fi
+
+      - name: Confirm no secrets were baked into the image
+        run: |
+          if docker run --rm --entrypoint sh nodum-${{ matrix.name }}:ci -c 'ls -a /app/.env /app/.git 2>/dev/null' | grep -q .; then
+            echo "::error::nodum-${{ matrix.name }} image contains .env or .git"
+            exit 1
+          fi
+          echo "clean"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,84 @@
+name: Security
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+  schedule:
+    # A dependency that was clean on merge is not clean forever — advisories
+    # land against versions already in the lockfile.
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python-audit:
+    name: Python dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.3"
+          enable-cache: true
+          cache-dependency-glob: back/uv.lock
+
+      # Audit what actually ships: --no-dev keeps a pytest advisory from
+      # failing a production gate.
+      - name: Export runtime dependencies
+        working-directory: back
+        run: uv export --frozen --no-dev --no-emit-project --no-hashes --format requirements-txt -o requirements.txt
+
+      - name: pip-audit
+        working-directory: back
+        run: uvx pip-audit@2.9.0 -r requirements.txt
+
+  node-audit:
+    name: Node dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      # --omit=dev for the same reason: an advisory in build tooling is worth
+      # knowing about but is not shipped to a user, and a gate that fails on
+      # things you cannot act on gets ignored.
+      - name: npm audit
+        run: npm audit --omit=dev --audit-level=high
+
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Needs the dependency graph, which on a private repo requires Advanced
+    # Security. Turns on by itself when the repo goes public.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.repository.visibility == 'public'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/back/app/api/v1/links.py
+++ b/back/app/api/v1/links.py
@@ -54,15 +54,33 @@ async def related_notes(
     if target is None:
         return {"data": {"related": []}}
 
+    from sqlalchemy import text as sql_text
+    from sqlalchemy.exc import DBAPIError
+
+    from app.constants import limits
+
     distance = Note.embedding.cosine_distance(target)
-    rows = (
-        await db.execute(
-            select(Note.id, Note.title, Note.path, distance.label("distance"))
-            .where(Note.vault_id == vault_id, Note.id != note_id, Note.embedding.is_not(None))
-            .order_by(distance)
-            .limit(limit)
-        )
-    ).all()
+    try:
+        # Exact sequential scan, bounded in time — the same bargain
+        # get_unlinked_mentions makes. There is no ANN index and cannot be a
+        # table-wide one: pgvector post-filters HNSW, so with a vault_id
+        # predicate it would return the globally-nearest vectors and only then
+        # apply the tenant filter, yielding empty or wrong results.
+        await db.execute(sql_text(f"SET LOCAL statement_timeout = {int(limits.RELATED_NOTES_TIMEOUT_MS)}"))
+        rows = (
+            await db.execute(
+                select(Note.id, Note.title, Note.path, distance.label("distance"))
+                .where(Note.vault_id == vault_id, Note.id != note_id, Note.embedding.is_not(None))
+                .order_by(distance)
+                .limit(limit)
+            )
+        ).all()
+    except DBAPIError:
+        # A vault big enough to blow the budget degrades to an empty pane
+        # rather than holding a worker and a connection.
+        await db.rollback()
+        return {"data": {"related": [], "timed_out": True}}
+
     related = [
         {"id": str(r.id), "title": r.title, "path": r.path, "similarity": round(1 - float(r.distance), 3)}
         for r in rows

--- a/back/app/api/v1/vault_io.py
+++ b/back/app/api/v1/vault_io.py
@@ -31,7 +31,15 @@ async def export_vault(vault_id: UUID, user_id: CurrentUserId, db: SessionDep) -
 @router.post("/import")
 async def import_vault(vault_id: UUID, file: UploadFile, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
     """Import a zip of markdown files (an Obsidian vault works as-is)."""
+    # Check BEFORE reading. Starlette's multipart parser has already counted
+    # the part (UploadFile.size is exact by the time a handler runs), so this
+    # is free — whereas reading first and measuring after commits the whole
+    # allocation the cap exists to prevent, and a multi-GB body OOM-kills the
+    # worker before any validation runs.
+    if (file.size or 0) > MAX_IMPORT_ZIP_SIZE_BYTES:
+        raise ValidationFailedError("Archive is too large.")
     archive = await file.read()
+    # Fallback for a hand-constructed UploadFile with no size (unit tests).
     if len(archive) > MAX_IMPORT_ZIP_SIZE_BYTES:
         raise ValidationFailedError("Archive is too large.")
     stats = (await vault_io_service.import_zip(db, vault_id, user_id, archive=archive)).unwrap()
@@ -57,10 +65,13 @@ async def import_files(
     total = 0
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
         for upload in files:
-            content = await upload.read()
-            total += len(content)
+            # Per-file, and before the read: the running total was already
+            # checked inside this loop, but a single oversized member was read
+            # into memory whole before `total` was ever consulted.
+            total += upload.size or 0
             if total > MAX_IMPORT_ZIP_SIZE_BYTES:
                 raise ValidationFailedError("Selection is too large.")
+            content = await upload.read()
             # filename carries the relative path; posixpath keeps separators sane
             name = (upload.filename or "file").replace("\\", "/").lstrip("/")
             if not name or name.endswith("/"):

--- a/back/app/constants/limits.py
+++ b/back/app/constants/limits.py
@@ -6,6 +6,12 @@ MAX_NOTES_PER_VAULT = 100_000
 MAX_FOLDER_DEPTH = 20
 MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB per attachment
 MAX_IMPORT_ZIP_SIZE_BYTES = 500 * 1024 * 1024  # 500 MB
+# Hard ceiling on any request body, enforced from Content-Length before routing.
+# FastAPI parses multipart (spooling to disk past ~1MB) *before* it resolves the
+# auth dependency, so without this an unauthenticated caller can fill the
+# container's disk. Sized above the import cap plus multipart overhead so it
+# never bites a legitimate upload.
+MAX_REQUEST_BODY_BYTES = MAX_IMPORT_ZIP_SIZE_BYTES + 16 * 1024 * 1024
 MAX_TITLE_LENGTH = 255
 MAX_PATH_LENGTH = 1024
 NOTE_VERSIONS_KEPT = 50

--- a/back/app/constants/limits.py
+++ b/back/app/constants/limits.py
@@ -28,3 +28,11 @@ MAX_BACKLINK_SOURCES = 200
 # Unlinked-mentions ILIKE scan budget — the pane degrades to empty on timeout
 # (decision: no pg_trgm GIN; 2MB contents make it enormous + write-heavy)
 UNLINKED_MENTIONS_TIMEOUT_MS = 2000
+# Related-notes cosine scan budget. Same bargain as above: exact results,
+# bounded time. Deliberately NOT an ANN index — the query filters on vault_id,
+# and pgvector post-filters an HNSW index, so a table-wide one would return the
+# globally-nearest rows and only then apply the tenant filter, handing back
+# empty or wrong results on a multi-tenant table. An index here would have to
+# be per-tenant (partitioning or partial indexes), which is a schema decision,
+# not a tuning one.
+RELATED_NOTES_TIMEOUT_MS = 2000

--- a/back/app/core/middlewares/body_size_middleware.py
+++ b/back/app/core/middlewares/body_size_middleware.py
@@ -1,0 +1,44 @@
+"""Reject oversized request bodies before anything reads them.
+
+FastAPI parses the multipart body while resolving the request, which happens
+*before* the auth dependency runs — so an unauthenticated caller can make the
+process spool gigabytes to the container's disk and then into RAM, and every
+handler-level size check fires too late to stop it.
+
+Content-Length is advisory (a chunked request omits it), so this is a cheap
+first line rather than the whole defence: the handlers still check
+UploadFile.size, and a reverse proxy in front should carry its own body cap.
+What this closes is the pre-auth case, which nothing else covers.
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from app.constants.limits import MAX_REQUEST_BODY_BYTES
+from app.core.logging import get_logger
+
+logger = get_logger("body_size")
+
+
+class MaxBodySizeMiddleware(BaseHTTPMiddleware):
+    """413 anything declaring a body larger than MAX_REQUEST_BODY_BYTES."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        declared = request.headers.get("content-length")
+        if declared:
+            try:
+                length = int(declared)
+            except ValueError:
+                # A malformed Content-Length is not something to forward on.
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": {"code": "bad_request", "message": "Invalid Content-Length."}},
+                )
+            if length > MAX_REQUEST_BODY_BYTES:
+                logger.warning("request_body_too_large", declared=length, path=request.url.path)
+                return JSONResponse(
+                    status_code=413,
+                    content={"error": {"code": "payload_too_large", "message": "Request body is too large."}},
+                )
+        return await call_next(request)

--- a/back/app/core/middlewares/rate_limit_middleware.py
+++ b/back/app/core/middlewares/rate_limit_middleware.py
@@ -14,7 +14,8 @@ from starlette.responses import JSONResponse, Response
 
 from app.core.logging import get_logger
 from app.core.redis import redis_control
-from app.settings import get_settings
+from app.settings import CommonSettings, get_settings
+from app.utils.jwt_utils import decode_token
 
 logger = get_logger("rate_limit")
 
@@ -22,8 +23,54 @@ AUTH_PREFIX = "/api/v1/auth"
 EXEMPT_PATHS = ("/health", "/docs", "/openapi.json", "/redoc")
 
 
+def client_ip_from(request: Request, settings: CommonSettings) -> str:
+    """Resolve the client address, trusting X-Forwarded-For only as configured.
+
+    X-Forwarded-For is a chain the client can seed: a proxy *appends* the peer
+    it received from, so a request arriving as ``X-Forwarded-For: 1.2.3.4``
+    reaches us as ``1.2.3.4, <real client>``. Reading the leftmost entry — as
+    this used to — therefore hands the attacker their own rate-limit bucket
+    per forged value, which is an outright bypass of the auth brute-force
+    limit rather than a hardening gap.
+
+    Counting from the right is safe under both proxy conventions: appending
+    proxies leave the real client at ``-TRUSTED_PROXY_HOPS``, and replacing
+    proxies (nginx ``proxy_set_header X-Forwarded-For $remote_addr``) leave a
+    single entry that the same index selects.
+    """
+    direct = request.client.host if request.client else "unknown"
+    if not settings.TRUST_PROXY_HEADERS:
+        return direct
+
+    hops = [hop.strip() for hop in request.headers.get("X-Forwarded-For", "").split(",") if hop.strip()]
+    trusted = max(settings.TRUSTED_PROXY_HOPS, 1)
+    if len(hops) < trusted:
+        # Shorter chain than configured: either a hop was stripped or the
+        # setting is wrong. Either way every remaining entry is client-writable,
+        # so fall back to the socket address rather than trust one.
+        return direct
+    return hops[-trusted]
+
+
+def _authenticated_user(request: Request) -> str | None:
+    """User id from a valid bearer token, or None.
+
+    The middleware runs before routing, so the auth dependency has not resolved
+    yet; verifying the token here costs one HMAC. Without this the limiter keys
+    every authenticated request on IP, and the whole office behind one NAT — or
+    the entire deployment behind one reverse proxy — shares a single bucket,
+    which is what the module docstring already promised it did not do.
+    """
+    header = request.headers.get("Authorization", "")
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        return None
+    payload = decode_token(token.strip(), "access")
+    return str(payload["sub"]) if payload and payload.get("sub") else None
+
+
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Fixed-window rate limiter keyed by user id (from auth dep) or client IP."""
+    """Fixed-window rate limiter keyed by user id, falling back to client IP."""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         path = request.url.path
@@ -35,18 +82,19 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if settings.ENVIRONMENT in ("dev", "test"):
             return await call_next(request)
 
-        client_ip = request.client.host if request.client else "unknown"
-        if settings.TRUST_PROXY_HEADERS:
-            forwarded = request.headers.get("X-Forwarded-For", "")
-            if forwarded:
-                client_ip = forwarded.split(",")[0].strip() or client_ip
+        client_ip = client_ip_from(request, settings)
 
         if path.startswith(AUTH_PREFIX) and request.method == "POST":
+            # Always per-IP: these endpoints are what an attacker hits *before*
+            # holding a token, so there is no user to key on.
             key = f"rl:auth:{client_ip}"
             limit = settings.RATE_LIMIT_AUTH_REQUESTS
             window = settings.RATE_LIMIT_AUTH_WINDOW_SECONDS
         else:
-            key = f"rl:api:{client_ip}"
+            # Per-user where possible so one shared egress IP cannot exhaust
+            # everyone else's budget; per-IP only for anonymous traffic.
+            user_id = _authenticated_user(request)
+            key = f"rl:api:u:{user_id}" if user_id else f"rl:api:ip:{client_ip}"
             limit = settings.USER_RATE_LIMIT_REQUESTS_PER_MINUTE
             window = settings.USER_RATE_LIMIT_WINDOW_SECONDS
 

--- a/back/app/main.py
+++ b/back/app/main.py
@@ -12,6 +12,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from app.api.exceptions import register_exception_handlers
 from app.api.v1.router import api_router
 from app.core.logging import get_logger, setup_logging
+from app.core.middlewares.body_size_middleware import MaxBodySizeMiddleware
 from app.core.middlewares.cors_middleware import add_cors_middleware
 from app.core.middlewares.logging_middleware import LoggingMiddleware
 from app.core.middlewares.rate_limit_middleware import RateLimitMiddleware
@@ -106,6 +107,9 @@ def create_app() -> FastAPI:
     app.add_middleware(GZipMiddleware, minimum_size=1024)
     app.add_middleware(LoggingMiddleware)
     app.add_middleware(RateLimitMiddleware)
+    # Added last, so it is the outermost layer and an oversized body is
+    # rejected before any other middleware — or the multipart parser — sees it.
+    app.add_middleware(MaxBodySizeMiddleware)
 
     register_exception_handlers(app)
 

--- a/back/app/main.py
+++ b/back/app/main.py
@@ -56,8 +56,39 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     logger.info("app_stopped")
 
 
+def _init_sentry() -> None:
+    """Wire up error reporting when a DSN is configured.
+
+    sentry-sdk has been a declared dependency and SENTRY_DSN has been plumbed
+    through prod compose since the beginning, but nothing ever called init() —
+    so production has been silently reporting nothing.
+
+    PII stays off deliberately: this app's request bodies *are* the user's
+    private notes, and shipping them to a third party to debug a 500 would be
+    a worse bug than the 500.
+    """
+    settings = get_settings()
+    if not settings.SENTRY_DSN:
+        return
+
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.ENVIRONMENT,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        send_default_pii=False,
+        max_request_body_size="never",
+    )
+    logger.info("sentry_initialised", environment=settings.ENVIRONMENT)
+
+
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
+    # Before anything else: an exception raised while building the app should
+    # still be reported.
+    _init_sentry()
+
     openapi_config = get_openapi_config()
 
     app = FastAPI(

--- a/back/app/services/ai_providers.py
+++ b/back/app/services/ai_providers.py
@@ -18,6 +18,7 @@ from typing import Any
 import httpx
 
 from app.settings import get_settings
+from app.utils.url_guard import UnsafeUrlError, assert_safe_url
 
 
 @dataclass(frozen=True)
@@ -78,6 +79,25 @@ class ProviderError(RuntimeError):
 
 def base_url_for(provider: str, override: str | None) -> str:
     return (override or _DEFAULT_BASE_URLS[provider]).rstrip("/")
+
+
+async def _checked_base_url(provider: str, override: str | None) -> str:
+    """Resolve the provider root, refusing an override that points somewhere
+    the server must not reach.
+
+    Enforced here and not only in save_credential: a save-time check misses
+    every credential stored before the guard existed, and a hostname is free to
+    resolve differently on the second lookup. Built-in defaults skip the check
+    — they are ours, and resolving them on every call would add a DNS round
+    trip to the hot path.
+    """
+    if not override:
+        return _DEFAULT_BASE_URLS[provider].rstrip("/")
+    try:
+        await assert_safe_url(override, allow_private=get_settings().AI_ALLOW_PRIVATE_BASE_URLS)
+    except UnsafeUrlError as exc:
+        raise ProviderError(str(exc)) from exc
+    return override.rstrip("/")
 
 
 def _safe_error(provider: str, response: httpx.Response) -> ProviderError:
@@ -156,7 +176,7 @@ async def chat(
     """Send one turn and return the assistant's reply text."""
     if provider not in PROVIDERS:
         raise ProviderError(f"Unknown provider: {provider}")
-    url_root = base_url_for(provider, base_url)
+    url_root = await _checked_base_url(provider, base_url)
     timeout = httpx.Timeout(float(get_settings().AI_REQUEST_TIMEOUT))
 
     async with httpx.AsyncClient(timeout=timeout) as client:
@@ -234,7 +254,7 @@ async def turn(
     """
     if provider not in PROVIDERS:
         raise ProviderError(f"Unknown provider: {provider}")
-    url_root = base_url_for(provider, base_url)
+    url_root = await _checked_base_url(provider, base_url)
     timeout = httpx.Timeout(float(get_settings().AI_REQUEST_TIMEOUT))
 
     async with httpx.AsyncClient(timeout=timeout) as client:

--- a/back/app/services/ai_service.py
+++ b/back/app/services/ai_service.py
@@ -24,7 +24,9 @@ from app.services import ai_providers, ai_tools
 from app.services.ai_providers import PROVIDERS, ProviderError
 from app.services.service_response import ServiceResponse
 from app.services.vault_service import get_owned_vault
+from app.settings import get_settings
 from app.utils.crypto_utils import decrypt_secret, encrypt_secret, encryption_available, mask_secret
+from app.utils.url_guard import UnsafeUrlError, assert_safe_url
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +121,15 @@ async def save_credential(
 
     chosen_model = (model or "").strip() or (existing.model if existing else "") or PROVIDERS[provider].default_model
     endpoint = (base_url or "").strip() or None
+
+    # A custom endpoint is a URL the server will POST to with a bearer token.
+    # Reject it here as well as at request time so the user gets a clear error
+    # at the moment they set it, rather than a confusing failure later.
+    if endpoint is not None:
+        try:
+            await assert_safe_url(endpoint, allow_private=get_settings().AI_ALLOW_PRIVATE_BASE_URLS)
+        except UnsafeUrlError as exc:
+            return ServiceResponse.fail("validation_failed", str(exc))
 
     if existing is None:
         existing = AICredential(

--- a/back/app/services/auth_service.py
+++ b/back/app/services/auth_service.py
@@ -11,7 +11,7 @@ from app.models.auth import Session, User
 from app.services.service_response import ServiceResponse
 from app.settings import get_settings
 from app.utils.jwt_utils import create_access_token, create_refresh_token, decode_token, new_jti
-from app.utils.password_utils import hash_password, verify_password
+from app.utils.password_utils import hash_password_async, verify_password_async
 
 logger = get_logger("auth")
 
@@ -32,7 +32,7 @@ async def signup(db: AsyncSession, *, email: str, password: str, name: str) -> S
     if existing:
         return ServiceResponse.fail("already_exists", "An account with this email already exists.")
 
-    user = User(email=email, password_hash=hash_password(password), name=name.strip())
+    user = User(email=email, password_hash=await hash_password_async(password), name=name.strip())
     db.add(user)
     await db.flush()
 
@@ -56,7 +56,7 @@ async def login(
     """Verify credentials and mint a token pair backed by a session row."""
     email = email.strip().lower()
     user = await db.scalar(select(User).where(User.email == email))
-    if user is None or not verify_password(password, user.password_hash):
+    if user is None or not await verify_password_async(password, user.password_hash):
         # Same error for unknown email and wrong password — no account probing.
         return ServiceResponse.fail("unauthorized", "Invalid email or password.")
     if not user.is_active:
@@ -279,10 +279,10 @@ async def change_password(
     user = await db.get(User, user_id)
     if user is None:
         return ServiceResponse.fail("unauthorized", "Account is not available.")
-    if not verify_password(current_password, user.password_hash):
+    if not await verify_password_async(current_password, user.password_hash):
         return ServiceResponse.fail("unauthorized", "Current password is incorrect.")
 
-    user.password_hash = hash_password(new_password)
+    user.password_hash = await hash_password_async(new_password)
     result = await db.execute(select(Session).where(Session.user_id == user_id, Session.is_active.is_(True)))
     for s in result.scalars():
         s.invalidate("password_changed")

--- a/back/app/services/auth_service.py
+++ b/back/app/services/auth_service.py
@@ -191,6 +191,32 @@ async def refresh(db: AsyncSession, *, refresh_token: str) -> ServiceResponse[To
     )
 
 
+async def revoke_existing_sessions(db: AsyncSession, user_id: UUID, reason: str) -> None:
+    """Kill every session this user currently holds. The caller commits.
+
+    Deliberately per-session (``revoked_sid:``) rather than the user-wide
+    ``auth_revoked_user:`` marker used by change_password: that marker is
+    compared with ``iat <= revoked_at``, so a session minted in the same second
+    as the revocation would be killed too. Callers that revoke and then
+    immediately issue a new session — OAuth account linking — need the new one
+    to survive, and a fresh session id is never in this set.
+    """
+    result = await db.execute(select(Session).where(Session.user_id == user_id, Session.is_active.is_(True)))
+    sessions = list(result.scalars())
+    for session in sessions:
+        session.invalidate(reason)
+
+    try:
+        from app.core.redis import redis_control
+
+        settings = get_settings()
+        ttl = (settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES + 1) * 60
+        for session in sessions:
+            await redis_control.set(f"revoked_sid:{session.id}", "1", ex=ttl)
+    except Exception:
+        logger.warning("revocation_marker_failed")
+
+
 async def logout(db: AsyncSession, *, refresh_token: str | None) -> ServiceResponse[None]:
     """Invalidate the session and instantly revoke its outstanding access tokens."""
     if refresh_token:

--- a/back/app/services/link_service.py
+++ b/back/app/services/link_service.py
@@ -211,30 +211,55 @@ async def get_backlinks(
     if note is None:
         return ServiceResponse.fail("not_found", "Note not found.")
 
-    rows = (
+    from app.constants import limits
+
+    # Two queries on purpose. This used to be one, selecting Note.content over
+    # every link pointing here and applying MAX_BACKLINK_SOURCES in Python
+    # *after* Postgres had returned and decoded every row. On a hub note — an
+    # MOC, exactly the pattern this product is for — that transferred thousands
+    # of note bodies to render a 200-entry panel, on every note switch.
+    #
+    # Pass 1 picks the sources and their link counts, without touching content.
+    # Note is joined only for the ordering key, so truncation keeps the
+    # alphabetically-first 200 and stays stable across requests. The +1 row is
+    # the "is there more" sentinel.
+    source_rows = (
         await db.execute(
-            select(Link.count, Note.id, Note.title, Note.path, Note.content)
+            select(Link.source_note_id, Note.title, func.sum(Link.count).label("total"))
             .join(Note, Note.id == Link.source_note_id)
             .where(Link.vault_id == vault_id, Link.target_note_id == note_id)
+            .group_by(Link.source_note_id, Note.title)
             .order_by(Note.title)
+            .limit(limits.MAX_BACKLINK_SOURCES + 1)
         )
     ).all()
 
-    from app.constants import limits
+    truncated = len(source_rows) > limits.MAX_BACKLINK_SOURCES
+    source_rows = source_rows[: limits.MAX_BACKLINK_SOURCES]
+
+    # Pass 2 fetches at most MAX_BACKLINK_SOURCES bodies, for the snippets.
+    bodies: dict[UUID, tuple[str, str]] = {}
+    if source_rows:
+        body_rows = (
+            await db.execute(
+                select(Note.id, Note.path, Note.content).where(
+                    Note.vault_id == vault_id,
+                    Note.id.in_([row.source_note_id for row in source_rows]),
+                )
+            )
+        ).all()
+        bodies = {row.id: (row.path, row.content) for row in body_rows}
 
     by_source: dict[UUID, dict[str, Any]] = {}
-    truncated = False
-    for count, src_id, title, path, content in rows:
-        if src_id not in by_source and len(by_source) >= limits.MAX_BACKLINK_SOURCES:
-            truncated = True
-            continue
-        entry = by_source.setdefault(
-            src_id,
-            {"note_id": str(src_id), "title": title, "path": path, "count": 0, "snippets": []},
-        )
-        entry["count"] += count
-        if not entry["snippets"]:
-            entry["snippets"] = _snippets_for(content, [f"[[{note.title}", f"[[{note.path}"])
+    for src_id, title, total in source_rows:
+        path, content = bodies.get(src_id, ("", ""))
+        by_source[src_id] = {
+            "note_id": str(src_id),
+            "title": title,
+            "path": path,
+            "count": int(total or 0),
+            "snippets": _snippets_for(content, [f"[[{note.title}", f"[[{note.path}"]),
+        }
 
     payload: dict[str, Any] = {"note_id": str(note_id), "backlinks": list(by_source.values())}
     if truncated:

--- a/back/app/services/link_service.py
+++ b/back/app/services/link_service.py
@@ -302,7 +302,7 @@ async def get_unlinked_mentions(
                     Note.vault_id == vault_id,
                     Note.id != note_id,
                     Note.id.not_in(already_linking),
-                    Note.content.ilike(f"%{note.title}%"),
+                    Note.content.icontains(note.title, autoescape=True),
                 )
                 .limit(limit)
             )

--- a/back/app/services/oauth_service.py
+++ b/back/app/services/oauth_service.py
@@ -107,6 +107,16 @@ async def handle_google_callback(
     if not sub or not email:
         return ServiceResponse.fail("unauthorized", "Google profile is missing id or email.")
 
+    # Google returns email_verified alongside email, and an *unverified*
+    # address proves nothing about who is driving the flow. Without this check
+    # the branch below signs the caller into whatever local account happens to
+    # carry that address — account takeover with no password.
+    # Accept the string form too: some providers serialise it as "true".
+    verified = info.get("email_verified")
+    if verified is not True and str(verified).lower() != "true":
+        logger.warning("google_oauth_unverified_email", email=email)
+        return ServiceResponse.fail("unauthorized", "Google has not verified this email address.")
+
     connection = await db.scalar(
         select(OAuthConnection).where(OAuthConnection.provider == "google", OAuthConnection.provider_account_id == sub)
     )
@@ -119,6 +129,16 @@ async def handle_google_callback(
             if not created.success:
                 return created
             user = created.data
+        else:
+            # First time this Google identity attaches to an account that
+            # already existed locally. If somebody registered the address
+            # before its real owner showed up, this is where their foothold
+            # ends: every session they hold dies before we mint the new one.
+            await auth_service.revoke_existing_sessions(db, user.id, "oauth_account_linked")
+
+        # Google vouched for the address (checked above), so the column stops
+        # being decorative and becomes a usable trust signal.
+        user.email_verified = True
         db.add(OAuthConnection(user_id=user.id, provider="google", provider_account_id=sub, email=email))
         await db.commit()
 

--- a/back/app/services/search_service.py
+++ b/back/app/services/search_service.py
@@ -69,15 +69,15 @@ def _parse_date_range(raw: str) -> tuple[datetime | None, datetime | None]:
 
 def _apply_operators(stmt: Select, operators: dict[str, list[str]], vault_id: UUID) -> Select:
     for value in operators.get("path", []):
-        stmt = stmt.where(Note.path.ilike(f"%{value}%"))
+        stmt = stmt.where(Note.path.icontains(value, autoescape=True))
     for value in operators.get("file", []):
-        stmt = stmt.where(Note.title.ilike(f"%{value}%"))
+        stmt = stmt.where(Note.title.icontains(value, autoescape=True))
     for value in operators.get("tag", []):
         tag = value.lstrip("#").lower()
         tag_notes = (
             select(NoteTag.note_id)
             .join(Tag, Tag.id == NoteTag.tag_id)
-            .where(Tag.vault_id == vault_id, or_(Tag.name == tag, Tag.name.like(f"{tag}/%")))
+            .where(Tag.vault_id == vault_id, or_(Tag.name == tag, Tag.name.startswith(f"{tag}/", autoescape=True)))
         )
         stmt = stmt.where(Note.id.in_(tag_notes))
     for op_name, column in (("created", Note.created_at), ("updated", Note.updated_at)):
@@ -188,9 +188,11 @@ async def quick_switch(
             select(Note.id, Note.title, Note.path, similarity.label("score"))
             .where(
                 Note.vault_id == vault_id,
-                or_(Note.title.ilike(f"%{q}%"), Note.path.ilike(f"%{q}%"), similarity > 0.15),
+                or_(
+                    Note.title.icontains(q, autoescape=True), Note.path.icontains(q, autoescape=True), similarity > 0.15
+                ),
             )
-            .order_by(Note.title.ilike(f"{q}%").desc(), similarity.desc(), Note.updated_at.desc())
+            .order_by(Note.title.istartswith(q, autoescape=True).desc(), similarity.desc(), Note.updated_at.desc())
             .limit(limit)
         )
     ).all()
@@ -205,9 +207,9 @@ async def quick_switch(
             .join(Note, Note.id == NoteAlias.note_id)
             .where(
                 NoteAlias.vault_id == vault_id,
-                or_(NoteAlias.alias.ilike(f"%{q}%"), alias_similarity > 0.15),
+                or_(NoteAlias.alias.icontains(q, autoescape=True), alias_similarity > 0.15),
             )
-            .order_by(NoteAlias.alias.ilike(f"{q}%").desc(), alias_similarity.desc())
+            .order_by(NoteAlias.alias.istartswith(q, autoescape=True).desc(), alias_similarity.desc())
             .limit(limit)
         )
     ).all()

--- a/back/app/services/tag_service.py
+++ b/back/app/services/tag_service.py
@@ -77,7 +77,7 @@ async def notes_by_tag(
             .join(Tag, Tag.id == NoteTag.tag_id)
             .where(
                 Tag.vault_id == vault_id,
-                or_(Tag.name == tag_name, Tag.name.like(f"{tag_name}/%")),
+                or_(Tag.name == tag_name, Tag.name.startswith(f"{tag_name}/", autoescape=True)),
             )
             .distinct()
             .order_by(Note.title)

--- a/back/app/settings/common.py
+++ b/back/app/settings/common.py
@@ -50,7 +50,10 @@ class CommonSettings(BaseSettings):
     ] = "dev"
     DEBUG_MODE: bool = False
     LOG_LEVEL: str = "INFO"
-    SECRET_KEY: str = "change-me-in-production"
+    # Long enough that HS256 never sees an under-strength HMAC key (PyJWT
+    # raises InsecureKeyLengthWarning below 32 bytes), while still carrying the
+    # "change-me" fragment ProductionSettings refuses to boot on.
+    SECRET_KEY: str = "change-me-in-production-this-default-is-not-a-secret"
 
     # ── Database (component-based) ────────────────────────────────────────────
     POSTGRES_SERVER: str = "localhost"
@@ -102,7 +105,7 @@ class CommonSettings(BaseSettings):
     CACHE_TREE_TTL: int = 300
 
     # ── JWT ───────────────────────────────────────────────────────────────────
-    JWT_SECRET_KEY: str = "jwt-secret-change-me"
+    JWT_SECRET_KEY: str = "jwt-secret-change-me-this-default-is-not-a-secret"
     JWT_ALGORITHM: str = "HS256"
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
     JWT_REFRESH_TOKEN_EXPIRE_DAYS: int = 7
@@ -153,7 +156,12 @@ class CommonSettings(BaseSettings):
     TRUST_PROXY_HEADERS: bool = False
 
     # ── Monitoring ────────────────────────────────────────────────────────────
+    # Empty disables error reporting entirely (the default, and what every
+    # dev/test run uses). Set it and app.main wires up sentry-sdk.
     SENTRY_DSN: str = ""
+    # Errors only by default. Tracing is opt-in because every sampled
+    # transaction is billed and this app's hot paths are chatty.
+    SENTRY_TRACES_SAMPLE_RATE: float = 0.0
 
     # ── Semantic search ───────────────────────────────────────────────────────
     # hash (default, offline) | openai (needs OPENAI_API_KEY; same 384-dim column)

--- a/back/app/settings/common.py
+++ b/back/app/settings/common.py
@@ -119,6 +119,13 @@ class CommonSettings(BaseSettings):
     # Ceiling on a single AI request, in seconds — a provider hanging must not
     # hold a worker forever.
     AI_REQUEST_TIMEOUT: int = 120
+    # A user-supplied provider base_url is a URL the *server* fetches, so by
+    # default it may not resolve to a private, loopback, link-local or reserved
+    # address — otherwise any signed-up user can probe the cloud metadata
+    # endpoint or the compose network from inside the API container.
+    # Turn this on only on a single-tenant/self-hosted install, where pointing
+    # at http://ollama:11434/v1 is the whole point.
+    AI_ALLOW_PRIVATE_BASE_URLS: bool = False
 
     # ── S3 / MinIO (attachments) ──────────────────────────────────────────────
     S3_ENDPOINT_URL: str = "http://localhost:9000"
@@ -150,10 +157,18 @@ class CommonSettings(BaseSettings):
     RATE_LIMIT_AUTH_WINDOW_SECONDS: int = 60
     USER_RATE_LIMIT_REQUESTS_PER_MINUTE: int = 300
     USER_RATE_LIMIT_WINDOW_SECONDS: int = 60
-    # True when the API sits behind a trusted reverse proxy (prod compose):
-    # rate limiting then keys on the first X-Forwarded-For hop instead of the
+    # True when the API sits behind a trusted reverse proxy: rate limiting then
+    # reads the client address out of X-Forwarded-For instead of using the
     # proxy's socket IP (which would put every user in one shared bucket).
+    # Leave false when nothing trusted sits in front — the header is
+    # client-writable, so trusting it without a proxy is a rate-limit bypass.
     TRUST_PROXY_HEADERS: bool = False
+    # How many trusted proxies sit between the client and this app. The client
+    # address is read this many entries from the RIGHT of X-Forwarded-For, so a
+    # client-supplied prefix cannot displace it. 1 = a single reverse proxy
+    # (the shipped topology: Caddy/nginx, or the Next.js rewrite). Raise it if
+    # you add a CDN in front, or the CDN's address becomes the client.
+    TRUSTED_PROXY_HOPS: int = 1
 
     # ── Monitoring ────────────────────────────────────────────────────────────
     # Empty disables error reporting entirely (the default, and what every

--- a/back/app/settings/production.py
+++ b/back/app/settings/production.py
@@ -6,6 +6,15 @@ from app.settings.common import CommonSettings
 
 _PLACEHOLDER_FRAGMENTS = ("change-me", "changeme", "secret-change", "dev-only", "test-secret")
 
+# Values shipped in .env.example and the compose defaults. They are published
+# in a public repo, so booting production with any of them is the same as
+# having no credential at all.
+_DEFAULT_CREDENTIALS = frozenset({"nodum", "minioadmin", "postgres", "password", "admin", "changeme"})
+
+# Compose maps some settings from differently-named .env variables. Report the
+# name the operator actually edits, or the error sends them to the wrong line.
+_ENV_VAR_NAMES = {"S3_SECRET_KEY": "MINIO_ROOT_PASSWORD", "S3_ACCESS_KEY": "MINIO_ROOT_USER"}
+
 
 class ProductionSettings(CommonSettings):
     """Production overrides — strict defaults, fail-fast on placeholder secrets."""
@@ -18,6 +27,23 @@ class ProductionSettings(CommonSettings):
     def _reject_placeholder_secrets(self) -> "ProductionSettings":
         """A public repo ships known defaults — refusing to boot with them
         closes the door on accidental auth-bypass deployments."""
+        # The data-store credentials, which this guard used to skip entirely.
+        # An operator following the documented "copy .env.example, then fix
+        # whatever it complains about" loop otherwise ends up in production
+        # with minioadmin:minioadmin on the bucket holding every user's
+        # attachments, and nodum:nodum on the database — both published here.
+        for field in ("POSTGRES_PASSWORD", "S3_SECRET_KEY"):
+            value = getattr(self, field, "")
+            if (
+                value.lower() in _DEFAULT_CREDENTIALS
+                or len(value) < 12
+                or any(fragment in value.lower() for fragment in _PLACEHOLDER_FRAGMENTS)
+            ):
+                raise ValueError(
+                    f"{_ENV_VAR_NAMES.get(field, field)} is a known default or too short. Generate one: "
+                    'python3 -c "import secrets; print(secrets.token_urlsafe(24))"'
+                )
+
         for field in ("SECRET_KEY", "JWT_SECRET_KEY"):
             value = getattr(self, field, "")
             if len(value) < 32 or any(fragment in value.lower() for fragment in _PLACEHOLDER_FRAGMENTS):

--- a/back/app/utils/jwt_utils.py
+++ b/back/app/utils/jwt_utils.py
@@ -5,7 +5,8 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
-from jose import JWTError, jwt
+import jwt
+from jwt import PyJWTError
 
 from app.settings import get_settings
 
@@ -60,8 +61,18 @@ def decode_token(token: str, expected_type: str) -> dict[str, Any] | None:
     if settings.JWT_ALGORITHM not in _ALLOWED_JWT_ALGORITHMS:
         return None
     try:
-        payload = dict(jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]))
-    except JWTError:
+        payload = dict(
+            jwt.decode(
+                token,
+                settings.JWT_SECRET_KEY,
+                algorithms=[settings.JWT_ALGORITHM],
+                # Belt and braces on top of the allowlist above: PyJWT verifies
+                # exp by default, but be explicit about it and require the
+                # claims every token we mint actually carries.
+                options={"require": ["exp", "iat", "sub", "jti"], "verify_exp": True},
+            )
+        )
+    except PyJWTError:
         return None
     if payload.get("type") != expected_type:
         return None

--- a/back/app/utils/markdown_parse.py
+++ b/back/app/utils/markdown_parse.py
@@ -15,7 +15,6 @@ import re
 from dataclasses import dataclass
 
 _FRONTMATTER_RE = re.compile(r"\A---\n.*?\n(?:---|\.\.\.)\n", re.DOTALL)
-_FENCED_CODE_RE = re.compile(r"^(```|~~~).*?^\1[^\S\n]*$", re.DOTALL | re.MULTILINE)
 _INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
 
 _WIKILINK_RE = re.compile(r"(!?)\[\[([^\[\]\n]+?)\]\]")
@@ -35,6 +34,41 @@ class WikiLink:
     is_embed: bool  # ![[...]]
 
 
+def _strip_fenced_code(text: str) -> str:
+    """Remove fenced code blocks in a single linear pass.
+
+    This replaces ``^(```|~~~).*?^\\1[^\\S\\n]*$`` with DOTALL|MULTILINE, which
+    backtracked quadratically: an opening fence with no valid closing fence
+    made ``.*?`` expand across the whole remaining document before failing, and
+    the engine then retried from every subsequent fence. Measured at exactly 4x
+    per doubling — 3s at 80KB, extrapolating to ~35 minutes at the 2MB note
+    cap. Because link/tag extraction is synchronous CPU work inside an async
+    handler, that froze the entire uvicorn worker, not just the one request.
+
+    Semantics preserved from the regex: the fence must start at column 0, and
+    the closing line must contain only the same marker plus trailing blanks.
+
+    One deliberate change: an unterminated fence now swallows the rest of the
+    document rather than being ignored, which is what CommonMark and Obsidian
+    both do.
+    """
+    out: list[str] = []
+    fence: str | None = None
+    # split("\n"), not splitlines(): splitlines() also breaks on \v, \f, \x85
+    # and U+2028/9, which MULTILINE ^/$ do not treat as line boundaries. A note
+    # with a form feed inside a code block would otherwise close the fence
+    # early and leak [[links]] out of code.
+    for line in text.split("\n"):
+        if fence is None:
+            if line.startswith(("```", "~~~")):
+                fence = line[:3]
+                continue
+            out.append(line)
+        elif line.startswith(fence) and not line[len(fence) :].strip(" \t"):
+            fence = None
+    return "\n".join(out)
+
+
 def strip_non_content(markdown: str) -> str:
     """Remove frontmatter, fenced code blocks, and inline code spans.
 
@@ -42,7 +76,7 @@ def strip_non_content(markdown: str) -> str:
     not needed by callers; simple removal is enough for link/tag harvesting.
     """
     text = _FRONTMATTER_RE.sub("", markdown)
-    text = _FENCED_CODE_RE.sub("", text)
+    text = _strip_fenced_code(text)
     return _INLINE_CODE_RE.sub("", text)
 
 

--- a/back/app/utils/password_utils.py
+++ b/back/app/utils/password_utils.py
@@ -1,4 +1,17 @@
-"""Password hashing with Argon2id."""
+"""Password hashing with Argon2id.
+
+Argon2id is deliberately expensive — that is the point — which makes it exactly
+the wrong thing to run on the event loop. The library-recommended parameters
+cost tens of milliseconds of solid CPU per call, and every one of those
+milliseconds is time the worker cannot serve any other request: a burst of
+logins stalls note saves, searches and health checks alike.
+
+The sync functions stay for callers already off the loop (tests, scripts,
+threads); async endpoints use the `_async` variants, which hand the work to a
+thread.
+"""
+
+import asyncio
 
 from argon2 import PasswordHasher
 from argon2.exceptions import VerificationError, VerifyMismatchError
@@ -7,16 +20,26 @@ _hasher = PasswordHasher()  # argon2id with library-recommended parameters
 
 
 def hash_password(password: str) -> str:
-    """Hash a plaintext password."""
+    """Hash a plaintext password. Blocking — prefer hash_password_async."""
     return _hasher.hash(password)
 
 
 def verify_password(password: str, password_hash: str) -> bool:
-    """Verify a plaintext password against a stored hash."""
+    """Verify a plaintext password. Blocking — prefer verify_password_async."""
     try:
         return _hasher.verify(password_hash, password)
     except (VerifyMismatchError, VerificationError):
         return False
+
+
+async def hash_password_async(password: str) -> str:
+    """Hash off the event loop, so signup does not stall the whole worker."""
+    return await asyncio.to_thread(hash_password, password)
+
+
+async def verify_password_async(password: str, password_hash: str) -> bool:
+    """Verify off the event loop, so login does not stall the whole worker."""
+    return await asyncio.to_thread(verify_password, password, password_hash)
 
 
 def needs_rehash(password_hash: str) -> bool:

--- a/back/app/utils/url_guard.py
+++ b/back/app/utils/url_guard.py
@@ -1,0 +1,84 @@
+"""Guard against server-side request forgery on user-supplied URLs.
+
+The AI provider `base_url` is a user-controlled address the *server* then makes
+authenticated POSTs to. Unvalidated, any signed-up user can aim it at the cloud
+metadata endpoint (169.254.169.254), at compose-network hostnames like
+``postgres``/``redis``/``minio``, or at an admin port on localhost — and the
+provider error mapping is descriptive enough to fingerprint what answered.
+
+Self-hosting is a legitimate use of the field (``http://ollama:11434/v1`` on a
+private address is the canonical case), so private destinations are refused by
+default but can be re-enabled with AI_ALLOW_PRIVATE_BASE_URLS rather than
+silently removed.
+"""
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+_ALLOWED_SCHEMES = ("http", "https")
+
+
+class UnsafeUrlError(ValueError):
+    """The URL is syntactically bad or resolves somewhere it must not."""
+
+
+def _is_forbidden(ip: str) -> bool:
+    try:
+        address = ipaddress.ip_address(ip)
+    except ValueError:
+        # Not parseable as an address — treat as unsafe rather than guess.
+        return True
+    return (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local  # 169.254.0.0/16 — cloud metadata lives here
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+async def assert_safe_url(url: str, *, allow_private: bool) -> None:
+    """Raise UnsafeUrlError unless `url` is a plain HTTP(S) URL we may call.
+
+    Resolution goes through the event loop's resolver, not a bare
+    ``socket.getaddrinfo``: this runs on the async request path, and blocking
+    DNS there would stall every other request on the worker.
+
+    Called at save time *and* immediately before each provider request. Save
+    time alone is not enough — it misses credentials stored before this guard
+    existed, and it is defeated by a name that resolves differently on the
+    second lookup.
+    """
+    parts = urlsplit(url)
+    if parts.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise UnsafeUrlError("Endpoint must start with http:// or https://.")
+    if parts.username or parts.password:
+        raise UnsafeUrlError("Endpoint must not embed credentials.")
+    if parts.fragment:
+        raise UnsafeUrlError("Endpoint must not contain a fragment.")
+
+    host = parts.hostname
+    if not host:
+        raise UnsafeUrlError("Endpoint is missing a host.")
+
+    if allow_private:
+        return
+
+    try:
+        infos = await asyncio.get_running_loop().getaddrinfo(
+            host, parts.port or (443 if parts.scheme == "https" else 80), proto=socket.IPPROTO_TCP
+        )
+    except OSError as exc:
+        raise UnsafeUrlError("Endpoint host could not be resolved.") from exc
+
+    # Every answer must be acceptable: one public A record alongside a private
+    # one would otherwise be enough to get through.
+    for info in infos:
+        if _is_forbidden(str(info[4][0])):
+            raise UnsafeUrlError(
+                "Endpoint resolves to a private or reserved address. "
+                "Set AI_ALLOW_PRIVATE_BASE_URLS=true to allow self-hosted endpoints."
+            )

--- a/back/build/Dockerfile.api
+++ b/back/build/Dockerfile.api
@@ -1,29 +1,36 @@
 # ============================================================
 # Nodum API — Multi-stage Dockerfile
 # ============================================================
+# The production stage is built from a clean base rather than inheriting the
+# builder. The previous layout shipped build-essential and libpq-dev in the
+# runtime image, which was both ~300MB of dead weight and the source of every
+# OS-level CVE Trivy reported (libpq5/libpq-dev). Nothing at runtime needs
+# them: the app talks to Postgres through asyncpg, which speaks the wire
+# protocol itself and does not link libpq.
 
-# ── Base stage ────────────────────────────────────────────
-FROM python:3.13-slim-bookworm AS base
+# ── Builder ───────────────────────────────────────────────
+FROM python:3.13-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
-    curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv (pinned version for reproducible builds)
+# uv pinned for reproducible builds (matches UV_VERSION in the CI workflows)
 COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 
-# Copy dependency files first (cache layer)
-COPY pyproject.toml uv.lock ./
+# Bytecode is compiled here rather than on every container start.
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
 
-# Install dependencies (locked, no project package)
+# Dependency files first: this layer is cached until the lock changes.
+COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev --no-install-project --frozen
 
-# ── Development stage ─────────────────────────────────────
-FROM base AS development
+# ── Development ───────────────────────────────────────────
+FROM builder AS development
 
 RUN uv sync --no-install-project --frozen
 
@@ -37,25 +44,54 @@ EXPOSE 8000
 ENTRYPOINT ["./scripts/pre-start.sh"]
 CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
-# ── Production stage ──────────────────────────────────────
-FROM base AS production
+# ── Production ────────────────────────────────────────────
+FROM python:3.13-slim-bookworm AS production
 
-COPY . .
+# Base-layer security patches, then strip pip out of the runtime.
+#
+# pip is dead weight here — uv is a standalone binary and UV_NO_SYNC=1 means
+# nothing installs at runtime — and it is not inert: Trivy flags advisories
+# against the copies pip *vendors* (msgpack, setuptools), which no dependency
+# update can ever clear because they are not dependencies. Removing pip removes
+# the whole class, and drops an installer from an image running user content.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir --upgrade "setuptools>=78.1.1" \
+    && rm -rf "$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"/pip \
+              "$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"/pip-*.dist-info \
+              /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.13 \
+              /root/.cache
 
-# Non-root user (no home dir) — uv must not try to sync or write caches
+# uv stays in the runtime: the celery worker's compose command is `uv run
+# celery ...`, and pre-start.sh shells out through it too.
+COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
 ENV UV_NO_SYNC=1 \
-    UV_CACHE_DIR=/tmp/uv-cache
+    UV_CACHE_DIR=/tmp/uv-cache \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
 
-RUN groupadd -r nodum && useradd -r -g nodum nodum \
-    && chown -R nodum:nodum /app \
-    && chmod +x ./scripts/pre-start.sh
+RUN groupadd -r nodum && useradd -r -g nodum nodum
+
+# The venv stays root-owned and world-readable: the app only needs to read it,
+# and a non-root process that cannot rewrite its own interpreter is a smaller
+# target. --chown on COPY also avoids the `chown -R` that used to duplicate the
+# entire ~160MB virtualenv into a second layer.
+COPY --from=builder /app/.venv /app/.venv
+COPY --chown=nodum:nodum . .
+
+RUN chmod +x ./scripts/pre-start.sh
 
 USER nodum
 
 EXPOSE 8000
 
+# python rather than curl, so the runtime image needs no HTTP client package.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD python -c "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health', timeout=4).status == 200 else 1)" || exit 1
 
 ENTRYPOINT ["./scripts/pre-start.sh"]
 

--- a/back/pyproject.toml
+++ b/back/pyproject.toml
@@ -6,41 +6,46 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     # Web framework
-    "fastapi>=0.135.1",
-    "uvicorn[standard]>=0.41.0",
-    "python-multipart>=0.0.22",
+    "fastapi>=0.141.1",
+    "uvicorn[standard]>=0.52.3",
+    "python-multipart>=0.0.32",
     # Database
-    "sqlalchemy[asyncio]>=2.0.47",
+    "sqlalchemy[asyncio]>=2.0.52",
     "asyncpg>=0.31.0",
-    "alembic>=1.18.4",
+    "alembic>=1.19.1",
     # Validation & settings
-    "pydantic[email]>=2.12.5",
-    "pydantic-settings>=2.13.1",
+    "pydantic[email]>=2.13.4",
+    "pydantic-settings>=2.15.0",
     # Auth
-    "python-jose[cryptography]>=3.5.0",
-    # Fernet, for encrypting users' AI provider keys at rest. Present
-    # transitively via python-jose today — declared here because we import it
-    # directly and must not depend on another package's extras.
-    "cryptography>=45.0.0",
+    # PyJWT, not python-jose: python-jose is effectively unmaintained and drags
+    # in `ecdsa`, which carries an unfixable timing-attack advisory
+    # (PYSEC-2026-1325 — upstream states it is not side-channel resistant and
+    # will not be). PyJWT covers every algorithm in _ALLOWED_JWT_ALGORITHMS
+    # using `cryptography`, and drops ecdsa/rsa/pyasn1 from the tree entirely.
+    "pyjwt>=2.10.1",
+    # Fernet, for encrypting users' AI provider keys at rest, and PyJWT's
+    # backend for the RS* algorithms.
+    "cryptography>=50.0.0",
     "argon2-cffi>=25.1.0",
-    # Redis
-    # Capped at <6.5: kombu (celery's transport layer) hard-limits redis to <6.5.
-    # Upgrade to >=7 once kombu 5.7.0 ships to PyPI.
-    "redis[hiredis]>=6.0.0,<6.5",
+    # Redis — still capped: kombu 5.6.2 (celery's transport layer) declares
+    # `redis!=4.5.5,!=5.0.2,<6.5,>=4.5.2`, so redis 8.x cannot be resolved no
+    # matter what we ask for. The cap is kept explicit so the ceiling is
+    # visible here rather than surfacing as a mystery during a later upgrade.
+    # Re-check with `grep Requires-Dist: redis .venv/.../kombu-*/METADATA`.
+    "redis[hiredis]>=6.4.0,<6.5",
     # HTTP client
     "httpx>=0.28.1",
     # Background jobs (vault import/export, unlinked-mention scans)
-    "celery[redis]>=5.6.2",
+    "celery[redis]>=5.6.3",
     # Object storage (attachments)
-    "boto3>=1.42.59",
+    "boto3>=1.43.72",
     # Markdown / frontmatter parsing
-    "python-frontmatter>=1.1.0",
-    "pyyaml>=6.0.2",
+    "python-frontmatter>=1.3.0",
+    "pyyaml>=6.0.3",
     # Logging & monitoring
-    "structlog>=25.5.0",
-    "sentry-sdk[fastapi]>=2.53.0",
+    "structlog>=26.1.0",
+    "sentry-sdk[fastapi]>=2.68.0",
     # Utilities
-    "python-slugify>=8.0.4",
     "uuid7>=0.1.0",
     "pgvector>=0.5.0",
     "pycrdt>=0.14.2",
@@ -50,11 +55,11 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.1.0",
-    "pytest-cov>=7.0.0",
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
+    "pytest-cov>=7.1.0",
     "httpx>=0.28.1",
-    "ruff>=0.15.4",
+    "ruff>=0.16.3",
     "httpx-ws>=0.9.0",
 ]
 

--- a/back/tests/integration/test_ai_credentials.py
+++ b/back/tests/integration/test_ai_credentials.py
@@ -161,3 +161,47 @@ async def test_chat_without_a_key_says_so(client: AsyncClient, account: dict) ->
 async def test_ai_endpoints_require_authentication(client: AsyncClient) -> None:
     assert (await client.get("/api/v1/ai/status")).status_code == 401
     assert (await client.put("/api/v1/ai/credentials", json={"provider": "openai", "api_key": "x"})).status_code == 401
+
+
+async def test_private_base_url_is_refused(client: AsyncClient, account: dict) -> None:
+    """base_url is a URL the *server* fetches, so it must not reach inside.
+
+    Unvalidated, any signed-up user can aim it at the cloud metadata endpoint
+    or the compose network and read the provider error to fingerprint what
+    answered.
+    """
+    headers = _auth(account)
+    for endpoint in (
+        "http://169.254.169.254/latest/meta-data",  # cloud metadata
+        "http://127.0.0.1:8000",  # the API itself
+        "http://localhost:9000",  # MinIO
+        "http://10.0.0.5/v1",  # RFC1918
+    ):
+        resp = await client.put(
+            "/api/v1/ai/credentials",
+            headers=headers,
+            json={"provider": "openai", "api_key": SECRET_KEY_VALUE, "base_url": endpoint},
+        )
+        assert resp.status_code == 422, f"{endpoint} was accepted: {resp.text}"
+        assert resp.json()["error"]["code"] == "validation_failed"
+
+
+async def test_malformed_base_url_is_refused(client: AsyncClient, account: dict) -> None:
+    headers = _auth(account)
+    for endpoint in ("file:///etc/passwd", "gopher://x", "http://user:pw@example.com", "not-a-url"):
+        resp = await client.put(
+            "/api/v1/ai/credentials",
+            headers=headers,
+            json={"provider": "openai", "api_key": SECRET_KEY_VALUE, "base_url": endpoint},
+        )
+        assert resp.status_code == 422, f"{endpoint} was accepted: {resp.text}"
+
+
+async def test_public_base_url_is_still_allowed(client: AsyncClient, account: dict) -> None:
+    """Self-hosting on a public host stays supported — this is not a ban."""
+    resp = await client.put(
+        "/api/v1/ai/credentials",
+        headers=_auth(account),
+        json={"provider": "openai", "api_key": SECRET_KEY_VALUE, "base_url": "https://api.openai.com/v1"},
+    )
+    assert resp.status_code == 200, resp.text

--- a/back/tests/integration/test_import_export.py
+++ b/back/tests/integration/test_import_export.py
@@ -159,3 +159,34 @@ async def test_import_attachments_and_obsidian_config(client: AsyncClient, works
     settings = next(v for v in vaults.json()["data"] if v["id"] == workspace["vault_id"])["settings"]
     assert settings["dailyNoteFormat"] == "YYYY/MM/DD"
     assert settings["dailyNoteFolder"] == "Journal"
+
+
+async def test_oversized_body_is_rejected_before_it_is_read(client: AsyncClient, workspace: dict) -> None:
+    """The cap must bite on Content-Length, not after the bytes are in RAM.
+
+    FastAPI parses multipart before resolving auth, so a handler-level check
+    fires too late to stop an unauthenticated caller filling the disk.
+    """
+    from app.constants.limits import MAX_REQUEST_BODY_BYTES
+
+    auth, vault_id = workspace["headers"], workspace["vault_id"]
+
+    # Declare a huge body without sending one — if the guard works, the request
+    # is refused on the header alone.
+    resp = await client.post(
+        f"/api/v1/vaults/{vault_id}/import",
+        headers={**auth, "Content-Length": str(MAX_REQUEST_BODY_BYTES + 1), "Content-Type": "application/octet-stream"},
+        content=b"",
+    )
+    assert resp.status_code == 413
+    assert resp.json()["error"]["code"] == "payload_too_large"
+
+
+async def test_malformed_content_length_is_rejected(client: AsyncClient, workspace: dict) -> None:
+    auth, vault_id = workspace["headers"], workspace["vault_id"]
+    resp = await client.post(
+        f"/api/v1/vaults/{vault_id}/import",
+        headers={**auth, "Content-Length": "not-a-number", "Content-Type": "application/octet-stream"},
+        content=b"",
+    )
+    assert resp.status_code == 400

--- a/back/tests/integration/test_links_graph.py
+++ b/back/tests/integration/test_links_graph.py
@@ -184,3 +184,32 @@ async def test_folder_rename_reresolves_path_links(client: AsyncClient, workspac
     await _create(client, workspace, "Fresh pointer", "Now [[Archive/Spec]].")
     back3 = await client.get(f"{base}/notes/{target_id}/backlinks", headers=workspace["headers"])
     assert [b["title"] for b in back3.json()["data"]["backlinks"]] == ["Fresh pointer"]
+
+
+async def test_backlinks_counts_and_ordering_survive_the_two_query_split(client: AsyncClient, workspace: dict) -> None:
+    """Backlinks now select sources first and bodies second, capped in SQL.
+
+    Previously one query pulled every linking note's full body and applied
+    MAX_BACKLINK_SOURCES in Python — a hub note transferred thousands of bodies
+    to render a 200-entry panel. This pins the behaviour the split must keep:
+    per-source link counts are summed, and sources come back title-ordered.
+    """
+    headers = workspace["headers"]
+    base = f"/api/v1/vaults/{workspace['vault_id']}"
+
+    hub = await _create(client, workspace, "Hub", "hub\n")
+    # Zebra links to Hub twice, Alpha once — counts must aggregate per source.
+    await _create(client, workspace, "Zebra", "see [[Hub]] and again [[Hub]]\n")
+    await _create(client, workspace, "Alpha", "see [[Hub]]\n")
+
+    body = (await client.get(f"{base}/notes/{hub['id']}/backlinks", headers=headers)).json()["data"]
+
+    titles = [b["title"] for b in body["backlinks"]]
+    assert titles == sorted(titles), f"sources must come back title-ordered: {titles}"
+    counts = {b["title"]: b["count"] for b in body["backlinks"]}
+    assert counts["Zebra"] == 2, f"link counts not summed per source: {counts}"
+    assert counts["Alpha"] == 1
+    # Snippets and path still come from the source body, fetched separately now.
+    zebra = next(b for b in body["backlinks"] if b["title"] == "Zebra")
+    assert zebra["snippets"], "snippet lost when bodies moved to the second query"
+    assert zebra["path"], "path lost when it moved to the second query"

--- a/back/tests/integration/test_oauth.py
+++ b/back/tests/integration/test_oauth.py
@@ -18,14 +18,21 @@ def google_enabled(monkeypatch: pytest.MonkeyPatch):
     return s
 
 
-def _mock_google(monkeypatch: pytest.MonkeyPatch, *, sub: str, email: str, name: str = "Mock User"):
+def _mock_google(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    sub: str,
+    email: str,
+    name: str = "Mock User",
+    email_verified: object = True,
+):
     async def fake_exchange(code: str) -> str:
         assert code == "good-code"
         return "mock-access-token"
 
     async def fake_userinfo(token: str) -> dict:
         assert token == "mock-access-token"
-        return {"sub": sub, "email": email, "name": name}
+        return {"sub": sub, "email": email, "name": name, "email_verified": email_verified}
 
     monkeypatch.setattr(oauth_service, "_exchange_code", fake_exchange)
     monkeypatch.setattr(oauth_service, "_fetch_userinfo", fake_userinfo)
@@ -117,3 +124,63 @@ async def test_repeat_callback_reuses_user(
         ids.append(refresh.json()["data"]["user"]["id"])
         client.cookies.clear()
     assert ids[0] == ids[1]
+
+
+async def test_callback_rejects_unverified_google_email(
+    client: AsyncClient, google_enabled, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unverified address proves nothing about who is driving the flow.
+
+    Without this guard, anyone who can present a Google identity carrying a
+    victim's address is signed straight into that victim's account.
+    """
+    email = f"unverified-{uuid.uuid4().hex[:12]}@nodumtest.dev"
+    _mock_google(monkeypatch, sub=f"sub-{email}", email=email, email_verified=False)
+    state = await _start_state(client)
+
+    resp = await client.get(f"/api/v1/auth/google/callback?code=good-code&state={state}", follow_redirects=False)
+    assert resp.status_code == 307
+    assert "error" in resp.headers["location"]
+
+    # And no account was quietly created for it.
+    login = await client.post("/api/v1/auth/login", json={"email": email, "password": "whatever"})
+    assert login.status_code == 401
+    client.cookies.clear()
+
+
+async def test_linking_google_kills_sessions_held_before_the_link(
+    client: AsyncClient, google_enabled, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Closes the pre-registration hijack.
+
+    Someone who signs up with an address they do not own keeps a live session
+    until the real owner arrives via Google. Linking must evict them — while
+    leaving the session just minted for the genuine owner working.
+    """
+    email = f"prereg-{uuid.uuid4().hex[:12]}@nodumtest.dev"
+    signup = await client.post(
+        "/api/v1/auth/signup",
+        json={"email": email, "password": "s3cure-Password!", "name": "Squatter"},
+    )
+    squatter_access = signup.json()["data"]["access_token"]
+    client.cookies.clear()
+
+    # The squatter's token works right up until the link.
+    before = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {squatter_access}"})
+    assert before.status_code == 200
+
+    _mock_google(monkeypatch, sub=f"sub-{email}", email=email)
+    state = await _start_state(client)
+    resp = await client.get(f"/api/v1/auth/google/callback?code=good-code&state={state}", follow_redirects=False)
+    assert resp.status_code == 307
+
+    after = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {squatter_access}"})
+    assert after.status_code == 401, "the pre-existing session survived account linking"
+
+    # The owner's brand-new session must NOT have been caught in the sweep —
+    # this is why linking revokes per-session instead of using the user-wide
+    # marker, which kills anything minted in the same second.
+    owner = await client.post("/api/v1/auth/refresh")
+    assert owner.status_code == 200
+    assert owner.json()["data"]["user"]["email"] == email
+    client.cookies.clear()

--- a/back/tests/integration/test_search_tags.py
+++ b/back/tests/integration/test_search_tags.py
@@ -169,3 +169,36 @@ async def test_date_operators_and_sort(client: AsyncClient, workspace: dict) -> 
 
     # results now expose created_at for client-side display
     assert "created_at" in r_sorted.json()["data"]["results"][0]
+
+
+async def test_like_wildcards_from_the_url_are_literals_not_wildcards(client: AsyncClient, workspace: dict) -> None:
+    """`%` in a tag path must match a tag literally named `%`, not every tag.
+
+    Unescaped, `Tag.name LIKE '%/%'` turned the tag filter into "any note with
+    any nested tag", silently defeating the filter the caller asked for.
+    """
+    auth, base = workspace["headers"], workspace["base"]
+
+    await client.post(base + "/notes", headers=auth, json={"title": "Tagged A", "content": "#alpha/one body"})
+    await client.post(base + "/notes", headers=auth, json={"title": "Tagged B", "content": "#beta/two body"})
+
+    resp = await client.get(f"{base}/tags/%25/notes", headers=auth)
+    assert resp.status_code == 200
+    assert resp.json()["data"] == [], "a literal '%' tag matched every nested tag"
+
+    # The real tag still resolves, so the escaping did not break normal lookup.
+    real = await client.get(f"{base}/tags/alpha/notes", headers=auth)
+    assert [n["title"] for n in real.json()["data"]] == ["Tagged A"]
+
+
+async def test_search_operators_escape_wildcards(client: AsyncClient, workspace: dict) -> None:
+    auth, base = workspace["headers"], workspace["base"]
+    await client.post(base + "/notes", headers=auth, json={"title": "Wildcard Probe", "content": "body"})
+
+    body = (await client.get(f"{base}/search", headers=auth, params={"q": "path:%"})).json()["data"]
+    assert body["total"] == 0, "path:% matched every note instead of a literal percent"
+    assert body["results"] == []
+
+    # A literal path fragment still matches, so escaping did not break the operator.
+    real = (await client.get(f"{base}/search", headers=auth, params={"q": "path:Wildcard"})).json()["data"]
+    assert real["total"] >= 1

--- a/back/tests/unit/test_markdown_parse.py
+++ b/back/tests/unit/test_markdown_parse.py
@@ -1,6 +1,6 @@
 """Unit tests for wikilink/tag extraction."""
 
-from app.utils.markdown_parse import extract_tags, extract_wikilinks, frontmatter_tags
+from app.utils.markdown_parse import extract_tags, extract_wikilinks, frontmatter_tags, strip_non_content
 
 
 def test_basic_wikilink() -> None:
@@ -56,3 +56,47 @@ def test_frontmatter_tags() -> None:
     assert frontmatter_tags({"tags": ["Alpha", "#beta/gamma "]}) == {"alpha", "beta/gamma"}
     assert frontmatter_tags({"tags": "solo"}) == {"solo"}
     assert frontmatter_tags({}) == set()
+
+
+def test_fenced_code_stripping_is_linear() -> None:
+    """Guards against the quadratic regex this replaced.
+
+    The old `^(```|~~~).*?^\\1[^\\S\\n]*$` backtracked at 4x per doubling: 3s
+    for 80KB, extrapolating to ~35 minutes at the 2MB note cap — and since
+    link extraction runs synchronously inside an async handler, one POST froze
+    the whole worker. 400k unterminated fences is the worst case; linear
+    scanning does it in well under a second.
+    """
+    import time
+
+    payload = "```x\n" * 400_000
+    started = time.perf_counter()
+    strip_non_content(payload)
+    assert time.perf_counter() - started < 2.0
+
+
+def test_unterminated_fence_swallows_the_rest() -> None:
+    """CommonMark/Obsidian behaviour, and a deliberate change from the regex.
+
+    The old pattern needed a matching closing fence, so it stripped nothing
+    here and [[B]] became a link. An unterminated fence now runs to EOF.
+    """
+    links = extract_wikilinks("[[A]]\n```\n[[B]]\n")
+    assert [link.target for link in links] == ["A"]
+
+
+def test_fence_must_start_at_column_zero() -> None:
+    """An indented fence is not a fence — same as the regex's ^(```|~~~)."""
+    links = extract_wikilinks("   ```\n[[Indented]]\n   ```\n")
+    assert [link.target for link in links] == ["Indented"]
+
+
+def test_closing_fence_tolerates_trailing_blanks_only() -> None:
+    links = extract_wikilinks("```\n[[Hidden]]\n```   \n[[Visible]]\n")
+    assert [link.target for link in links] == ["Visible"]
+
+
+def test_vertical_whitespace_does_not_close_a_fence() -> None:
+    """splitlines() would break on \\f and end the block early, leaking the link."""
+    links = extract_wikilinks("```\n\x0c[[StillInCode]]\n```\n[[Out]]\n")
+    assert [link.target for link in links] == ["Out"]

--- a/back/tests/unit/test_rate_limit_keys.py
+++ b/back/tests/unit/test_rate_limit_keys.py
@@ -1,0 +1,69 @@
+"""How the rate limiter decides *who* a request is.
+
+Getting this wrong is not a hardening gap but a bypass: reading the leftmost
+X-Forwarded-For entry lets a caller mint a fresh bucket per forged value and
+walk through the auth brute-force limit.
+"""
+
+from starlette.datastructures import Headers
+
+from app.core.middlewares.rate_limit_middleware import client_ip_from
+from app.settings.common import CommonSettings
+
+
+class _Client:
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class _Request:
+    """Just the two attributes client_ip_from touches."""
+
+    def __init__(self, peer: str | None, forwarded: str | None = None) -> None:
+        self.client = _Client(peer) if peer else None
+        self.headers = Headers({"X-Forwarded-For": forwarded} if forwarded else {})
+
+
+def _settings(*, trust: bool, hops: int = 1) -> CommonSettings:
+    return CommonSettings(TRUST_PROXY_HEADERS=trust, TRUSTED_PROXY_HOPS=hops)
+
+
+def test_ignores_the_header_when_no_proxy_is_trusted() -> None:
+    request = _Request("10.0.0.9", forwarded="1.2.3.4")
+    assert client_ip_from(request, _settings(trust=False)) == "10.0.0.9"
+
+
+def test_forged_prefix_cannot_displace_the_real_client() -> None:
+    """A proxy appends, so a client-sent value ends up to the LEFT of the truth."""
+    request = _Request("10.0.0.9", forwarded="1.2.3.4, 203.0.113.7")
+    assert client_ip_from(request, _settings(trust=True)) == "203.0.113.7"
+
+
+def test_single_replacing_proxy() -> None:
+    """nginx `proxy_set_header X-Forwarded-For $remote_addr` leaves one entry."""
+    request = _Request("10.0.0.9", forwarded="203.0.113.7")
+    assert client_ip_from(request, _settings(trust=True)) == "203.0.113.7"
+
+
+def test_two_trusted_hops_skips_the_inner_proxy() -> None:
+    request = _Request("10.0.0.9", forwarded="203.0.113.7, 10.0.0.8")
+    assert client_ip_from(request, _settings(trust=True, hops=2)) == "203.0.113.7"
+
+
+def test_short_chain_falls_back_to_the_socket() -> None:
+    """Fewer hops than configured means every entry is client-writable."""
+    request = _Request("10.0.0.9", forwarded="1.2.3.4")
+    assert client_ip_from(request, _settings(trust=True, hops=2)) == "10.0.0.9"
+
+
+def test_empty_and_whitespace_entries_are_discarded() -> None:
+    request = _Request("10.0.0.9", forwarded=" , 203.0.113.7 ,")
+    assert client_ip_from(request, _settings(trust=True)) == "203.0.113.7"
+
+
+def test_missing_header_falls_back_to_the_socket() -> None:
+    assert client_ip_from(_Request("10.0.0.9"), _settings(trust=True)) == "10.0.0.9"
+
+
+def test_no_peer_at_all_is_not_a_crash() -> None:
+    assert client_ip_from(_Request(None), _settings(trust=False)) == "unknown"

--- a/back/tests/unit/test_settings_guard.py
+++ b/back/tests/unit/test_settings_guard.py
@@ -1,0 +1,45 @@
+"""Production must refuse to boot on any credential that ships in the repo.
+
+The guard used to cover SECRET_KEY/JWT_SECRET_KEY only, so an operator who
+followed "copy .env.example, fix what it complains about" got a production
+stack running on minioadmin:minioadmin and nodum:nodum — both published.
+"""
+
+import pytest
+
+from app.settings.production import ProductionSettings
+
+_GOOD = {
+    "SECRET_KEY": "a" * 40,
+    "JWT_SECRET_KEY": "b" * 40,
+    "POSTGRES_PASSWORD": "a-real-postgres-password",
+    "S3_SECRET_KEY": "a-real-minio-password",
+}
+
+
+def test_accepts_real_credentials() -> None:
+    assert ProductionSettings(**_GOOD).POSTGRES_PASSWORD == "a-real-postgres-password"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("POSTGRES_PASSWORD", "nodum"),
+        ("POSTGRES_PASSWORD", "postgres"),
+        ("POSTGRES_PASSWORD", "short"),
+        ("S3_SECRET_KEY", "minioadmin"),
+        ("S3_SECRET_KEY", "admin"),
+        ("SECRET_KEY", "change-me-in-production-this-default-is-not-a-secret"),
+        ("JWT_SECRET_KEY", "too-short"),
+    ],
+)
+def test_rejects_defaults_and_short_values(field: str, value: str) -> None:
+    with pytest.raises(ValueError):
+        ProductionSettings(**{**_GOOD, field: value})
+
+
+def test_the_error_names_the_env_var_the_operator_edits() -> None:
+    """Compose maps MINIO_ROOT_PASSWORD -> S3_SECRET_KEY; naming the setting
+    would send them to a line that does not exist in their .env."""
+    with pytest.raises(ValueError, match="MINIO_ROOT_PASSWORD"):
+        ProductionSettings(**{**_GOOD, "S3_SECRET_KEY": "minioadmin"})

--- a/back/uv.lock
+++ b/back/uv.lock
@@ -148,30 +148,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.69"
+version = "1.43.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/8f/315e908f5abaab5deb77196117f66c1badc9093b03dc152b0b8231b0112b/boto3-1.43.69.tar.gz", hash = "sha256:76297a0b415849c63575ae08a4f1661b2dc8ee0100f104b86f98aa69b47fa2c7", size = 112666, upload-time = "2026-08-11T19:24:26.281Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/cc/f22093524c3b38e94ba2d0e6743d7e264f7190d149c8dceaf9603822c595/boto3-1.43.72.tar.gz", hash = "sha256:6280ce03cc85e9110fd9fb7e2fbf11eae0b1177cb041a0d69aa88edc9d178cf9", size = 112688, upload-time = "2026-08-14T19:24:53.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/57/67ebb743ab0556c14db656e91e49024f3e1b0585f1a15c2d025176fb3c1e/boto3-1.43.69-py3-none-any.whl", hash = "sha256:4eb494d05b2bd08a7eee61b8ac4c34745c99e9bbce435c91f8d15d372dd8c2db", size = 140024, upload-time = "2026-08-11T19:24:25.022Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b7/fa7b827ce0fc9bd697381e40f59d69a74c6ab553e246271685ec0acc75b2/boto3-1.43.72-py3-none-any.whl", hash = "sha256:f1bbbad5ed8d8a8c64edb0cd092dc443c95a85623b2ac88b6f6d633717605f00", size = 140025, upload-time = "2026-08-14T19:24:52.013Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.69"
+version = "1.43.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/da/726b23443ebc77078387fbf330ef7240bc6a96553e566e45a647cd8f714c/botocore-1.43.69.tar.gz", hash = "sha256:5caa46b740d9a886137146ffbb69edb691f702bfe74c64e85621947ae00181fd", size = 15911844, upload-time = "2026-08-11T19:24:20.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/99/a8cfeaea98d5085a493af909d09d174466482235a7fda291be18c9a5a76e/botocore-1.43.72.tar.gz", hash = "sha256:1b878c69081e8e9d55aa4c0d85683e7b07f0e274a5554662f9507a46641be3d2", size = 15949280, upload-time = "2026-08-14T19:24:48.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/ef/a1effbe4ffabadc38ea9425c54601262eaac8cbb5b6089f8f76536d3c8b1/botocore-1.43.69-py3-none-any.whl", hash = "sha256:b1f0e01c53d6b84ee9c184ebf3636c3b3aef85e0ae8498c74afb8734ff224f87", size = 15596589, upload-time = "2026-08-11T19:24:18.283Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/35814fd8701a6b8be0aa47a7fcbd1ea0706189410a47d71ff29ddcc3ad4d/botocore-1.43.72-py3-none-any.whl", hash = "sha256:de5a1bcf8d7602c6cefc15016f15dad82981e339192531f31fa9483e11feea47", size = 15641880, upload-time = "2026-08-14T19:24:45.882Z" },
 ]
 
 [[package]]
@@ -480,18 +480,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -840,11 +828,10 @@ dependencies = [
     { name = "pycrdt-websocket" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "pypdf" },
     { name = "python-frontmatter" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
-    { name = "python-slugify" },
     { name = "pyyaml" },
     { name = "redis", extra = ["hiredis"] },
     { name = "sentry-sdk", extra = ["fastapi"] },
@@ -866,41 +853,40 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "alembic", specifier = ">=1.18.4" },
+    { name = "alembic", specifier = ">=1.19.1" },
     { name = "argon2-cffi", specifier = ">=25.1.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
-    { name = "boto3", specifier = ">=1.42.59" },
-    { name = "celery", extras = ["redis"], specifier = ">=5.6.2" },
-    { name = "cryptography", specifier = ">=45.0.0" },
-    { name = "fastapi", specifier = ">=0.135.1" },
+    { name = "boto3", specifier = ">=1.43.72" },
+    { name = "celery", extras = ["redis"], specifier = ">=5.6.3" },
+    { name = "cryptography", specifier = ">=50.0.0" },
+    { name = "fastapi", specifier = ">=0.141.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pgvector", specifier = ">=0.5.0" },
     { name = "pycrdt", specifier = ">=0.14.2" },
     { name = "pycrdt-websocket", specifier = ">=0.16.4" },
-    { name = "pydantic", extras = ["email"], specifier = ">=2.12.5" },
-    { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
+    { name = "pydantic-settings", specifier = ">=2.15.0" },
+    { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pypdf", specifier = ">=6.16.1" },
-    { name = "python-frontmatter", specifier = ">=1.1.0" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.5.0" },
-    { name = "python-multipart", specifier = ">=0.0.22" },
-    { name = "python-slugify", specifier = ">=8.0.4" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "redis", extras = ["hiredis"], specifier = ">=6.0.0,<6.5" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.53.0" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.47" },
-    { name = "structlog", specifier = ">=25.5.0" },
+    { name = "python-frontmatter", specifier = ">=1.3.0" },
+    { name = "python-multipart", specifier = ">=0.0.32" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "redis", extras = ["hiredis"], specifier = ">=6.4.0,<6.5" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.68.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.52" },
+    { name = "structlog", specifier = ">=26.1.0" },
     { name = "uuid7", specifier = ">=0.1.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-ws", specifier = ">=0.9.0" },
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.1.0" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "ruff", specifier = ">=0.15.4" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "ruff", specifier = ">=0.16.3" },
 ]
 
 [[package]]
@@ -940,15 +926,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
-]
-
-[[package]]
-name = "pyasn1"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -1125,6 +1102,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
 name = "pypdf"
 version = "6.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1209,43 +1195,12 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
-]
-
-[[package]]
-name = "python-slugify"
-version = "8.0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "text-unidecode" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -1299,40 +1254,28 @@ hiredis = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "ruff"
-version = "0.16.2"
+version = "0.16.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
-    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
-    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
-    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
-    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
-    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
 ]
 
 [[package]]
@@ -1349,15 +1292,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.67.1"
+version = "2.68.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/8a/b2eec40df8a67bf073e244d29001d04ee365d163bc4f15efdfce35f53090/sentry_sdk-2.67.1.tar.gz", hash = "sha256:f263d8c9aa4137750640de8fb0ed5404df6bb564e20e4b59cb16a6eeba18d4ed", size = 990599, upload-time = "2026-08-10T13:05:55.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/94/23b7dd072acb9628907bd3f4fbf61794a7b12a9db8f33c1276f70ae5ac92/sentry_sdk-2.68.0.tar.gz", hash = "sha256:648c58e9887311a03470a41539e24bdbbf64a30ca4f5336f7e3dcc87276400b3", size = 1008854, upload-time = "2026-08-13T09:06:21.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/e2/70692eba662037cddf93391cbbf98297159f3038612e9b9a8129e16feb7a/sentry_sdk-2.67.1-py3-none-any.whl", hash = "sha256:a66bfbce1cd8a93c51c369d642ad85b46253ea7a6f7938141315b83e2823cda5", size = 515591, upload-time = "2026-08-10T13:05:54.213Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/9b/e2421d08956d0bc4691d995393d835e563886bff499d8fb10fdefae85a8d/sentry_sdk-2.68.0-py3-none-any.whl", hash = "sha256:538e56c2d03679d42f7c0cb5f1af73a7a510b00abc7e296c13ac49b107b713a4", size = 518670, upload-time = "2026-08-13T09:06:19.735Z" },
 ]
 
 [package.optional-dependencies]
@@ -1442,15 +1385,6 @@ wheels = [
 ]
 
 [[package]]
-name = "text-unidecode"
-version = "1.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,14 +1395,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.3"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/bc/4eae18cd40c65798a16267572ba346c11f599d44b01603dbd843342042bc/typing_inspection-0.4.3.tar.gz", hash = "sha256:c5f9ec1530b5c1e2c9bc34a84d9a3466ed1b2f3f2fa9f901368d9c5596210e4d", size = 76711, upload-time = "2026-08-10T09:39:18.063Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/f7/7a3935abdebd5cf18705a5f0335dd6a3a18bef3baa7cb9edc3b6b9922cc8/typing_inspection-0.4.3-py3-none-any.whl", hash = "sha256:5f42b23858a91e0b4ef521f5418f03a0da3c9216fd2995ef5e73463100e676cd", size = 14693, upload-time = "2026-08-10T09:39:16.693Z" },
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
 ]
 
 [[package]]
@@ -1512,15 +1446,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.1"
+version = "0.52.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/18/ccce41535dee1be77735592bd19965f3972c82e07ee703d324709496b716/uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd", size = 100571, upload-time = "2026-08-01T18:19:30.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d5/68e6e9bca63c0badf67002890a46d3784c958de45b65e1275ec583ca1f06/uvicorn-0.52.1-py3-none-any.whl", hash = "sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a", size = 79859, upload-time = "2026-08-01T18:19:29.294Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c", size = 79859, upload-time = "2026-08-13T16:50:01.323Z" },
 ]
 
 [package.optional-dependencies]

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -40,5 +40,19 @@ FRONTEND_BASE_URL=http://localhost:3000
 BACKEND_CORS_ORIGINS=http://localhost:3000
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 
+# ── Reverse proxy (production) ──────────────────────────────
+# Set true ONLY when a proxy you control (Caddy, nginx, a CDN) terminates
+# connections in front of the API. It makes rate limiting read the caller's
+# address from X-Forwarded-For instead of lumping every visitor into the
+# proxy's single bucket.
+# Leave false when nothing trusted sits in front: the header is client-
+# writable, so trusting it without a proxy lets anyone mint a fresh
+# rate-limit bucket per request and walk straight through the auth limit.
+TRUST_PROXY_HEADERS=false
+# Number of trusted proxies between the client and the API. The address is
+# taken this many hops from the RIGHT of X-Forwarded-For, so a forged prefix
+# is ignored. 1 = one reverse proxy. Add one for a CDN in front of it.
+TRUSTED_PROXY_HOPS=1
+
 # ── Monitoring (optional) ───────────────────────────────────
 SENTRY_DSN=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -23,6 +23,13 @@ LOG_LEVEL=DEBUG
 # users would have to re-enter theirs — it is not the same kind of secret as
 # SECRET_KEY, which can be rotated freely.
 AI_ENCRYPTION_KEY=
+# Allow AI provider base_url values that resolve to private/loopback addresses
+# (a self-hosted endpoint like http://ollama:11434/v1). The dev stack turns
+# this on for you. Leave it false in production: the value is user-supplied and
+# the server is what fetches it, so allowing private targets on a multi-tenant
+# install lets any user probe the cloud metadata endpoint and your internal
+# network from inside the API container.
+AI_ALLOW_PRIVATE_BASE_URLS=false
 
 # ── PostgreSQL ──────────────────────────────────────────────
 POSTGRES_USER=nodum

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -38,6 +38,11 @@ services:
       # Encrypts users' AI provider keys. Dev default so the feature works out
       # of the box; production refuses a placeholder (see settings/production.py).
       - AI_ENCRYPTION_KEY=${AI_ENCRYPTION_KEY:-dev-only-ai-encryption-key-change-me}
+      # Dev only: lets you point the AI provider at a self-hosted endpoint on
+      # the compose network or localhost (http://ollama:11434/v1). Production
+      # leaves this off — there it is an SSRF hole, since any signed-up user
+      # controls the value.
+      - AI_ALLOW_PRIVATE_BASE_URLS=${AI_ALLOW_PRIVATE_BASE_URLS:-true}
     ports:
       - "127.0.0.1:8000:8000"
     volumes:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -40,6 +40,12 @@ services:
       - BACKEND_BASE_URL=${BACKEND_BASE_URL:?set in deploy/.env}
       - FRONTEND_BASE_URL=${FRONTEND_BASE_URL:?set in deploy/.env}
       - BACKEND_CORS_ORIGINS=${BACKEND_CORS_ORIGINS:?set in deploy/.env}
+      # This service has no env_file, so a variable that is not listed here
+      # never reaches the container no matter what deploy/.env says. Without
+      # these two the API sees only the proxy's socket IP and every visitor
+      # shares one rate-limit bucket.
+      - TRUST_PROXY_HEADERS=${TRUST_PROXY_HEADERS:-false}
+      - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
       - SENTRY_DSN=${SENTRY_DSN:-}
     ports:
       - "127.0.0.1:8000:8000"

--- a/deploy/docker-compose.test.yml
+++ b/deploy/docker-compose.test.yml
@@ -8,8 +8,14 @@ services:
     container_name: nodum-postgres-test
     ports:
       - "127.0.0.1:55432:5432"
-    tmpfs:
-      - /var/lib/postgresql/data    # ephemeral — fast, wiped on down
+    # No tmpfs here. The base file already mounts the postgres_data named
+    # volume at /var/lib/postgresql/data, and Compose merges the two rather
+    # than letting the override win — so adding a tmpfs at the same target made
+    # the whole test environment fail to render ("target ... already mounted"),
+    # which meant `./compose.sh test up` and `make test-up` did not work at all.
+    # Ephemerality comes from the project name instead: compose.sh runs this
+    # stack as `nodum-test`, so the volume is nodum-test_postgres_data, and
+    # `make test-down` (down -v) removes it.
 
   redis:
     container_name: nodum-redis-test

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -39,6 +39,17 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Base patches, then strip npm out of the runtime. This stage runs
+# `node server.js` against a self-contained standalone bundle and never
+# installs anything, but the npm that ships in the base image carries its own
+# vendored tree (brace-expansion, tar, picomatch, sigstore, ip-address) which
+# accounted for every fixable HIGH/CRITICAL Trivy found here — none of them
+# reachable, none of them fixable by updating our dependencies.
+RUN apk upgrade --no-cache \
+    && rm -rf /usr/local/lib/node_modules/npm \
+              /usr/local/bin/npm /usr/local/bin/npx \
+              /root/.npm
+
 RUN addgroup -S nodum && adduser -S nodum -G nodum
 
 COPY --from=build --chown=nodum:nodum /app/.next/standalone ./

--- a/web/e2e/ai-chat.spec.ts
+++ b/web/e2e/ai-chat.spec.ts
@@ -65,7 +65,7 @@ test.beforeEach(() => {
 
 /** Store a key pointed at the stub, through the real API. */
 async function configureStubProvider(page: Page, baseUrl: string) {
-  const result = await page.evaluate(async (url) => {
+  const result = await page.evaluate(async ([url, key]) => {
     const token = (await (await fetch("/api/v1/auth/refresh", { method: "POST" })).json()).data
       .access_token;
     const resp = await fetch("/api/v1/ai/credentials", {
@@ -74,13 +74,13 @@ async function configureStubProvider(page: Page, baseUrl: string) {
       body: JSON.stringify({
         provider: "openai",
         // Not "sk-…": a vendor-shaped prefix trips secret scanners on every diff.
-        api_key: "fake-stub-e2e-key",
+        api_key: key,
         model: "stub-model",
         base_url: url,
       }),
     });
     return { status: resp.status, body: await resp.text() };
-  }, baseUrl);
+  }, [baseUrl, STUB_API_KEY]);
 
   // Check it. This used to be fire-and-forget, so when the server started
   // rejecting the stub's base_url every dependent test just timed out after
@@ -90,6 +90,10 @@ async function configureStubProvider(page: Page, baseUrl: string) {
     `stub provider was not configured (${result.status}): ${result.body}`,
   ).toBe(200);
 }
+
+// One constant: this literal is asserted against the header the stub receives,
+// and a rename that updated only one of the two sites broke CI.
+const STUB_API_KEY = "fake-stub-e2e-key";
 
 const openAiPanel = (page: Page) => page.getByRole("button", { name: "AI chat" }).click();
 
@@ -124,7 +128,7 @@ test.describe("AI chat panel", () => {
       headers: Record<string, string>;
       body: { messages: { role: string; content: string }[] };
     };
-    expect(sent.headers.authorization).toBe("Bearer sk-stub-e2e-key");
+    expect(sent.headers.authorization).toBe(`Bearer ${STUB_API_KEY}`);
     expect(sent.body.messages[0].content).toContain("Welcome to Nodum");
   });
 

--- a/web/e2e/ai-chat.spec.ts
+++ b/web/e2e/ai-chat.spec.ts
@@ -65,20 +65,30 @@ test.beforeEach(() => {
 
 /** Store a key pointed at the stub, through the real API. */
 async function configureStubProvider(page: Page, baseUrl: string) {
-  await page.evaluate(async (url) => {
+  const result = await page.evaluate(async (url) => {
     const token = (await (await fetch("/api/v1/auth/refresh", { method: "POST" })).json()).data
       .access_token;
-    await fetch("/api/v1/ai/credentials", {
+    const resp = await fetch("/api/v1/ai/credentials", {
       method: "PUT",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
       body: JSON.stringify({
         provider: "openai",
-        api_key: "sk-stub-e2e-key",
+        // Not "sk-…": a vendor-shaped prefix trips secret scanners on every diff.
+        api_key: "fake-stub-e2e-key",
         model: "stub-model",
         base_url: url,
       }),
     });
+    return { status: resp.status, body: await resp.text() };
   }, baseUrl);
+
+  // Check it. This used to be fire-and-forget, so when the server started
+  // rejecting the stub's base_url every dependent test just timed out after
+  // 30s x 3 attempts with no hint as to why.
+  expect(
+    result.status,
+    `stub provider was not configured (${result.status}): ${result.body}`,
+  ).toBe(200);
 }
 
 const openAiPanel = (page: Page) => page.getByRole("button", { name: "AI chat" }).click();

--- a/web/e2e/note-menu.spec.ts
+++ b/web/e2e/note-menu.spec.ts
@@ -299,6 +299,41 @@ test.describe("note menu", () => {
     ).toHaveCount(0);
   });
 
+  test("merge is adopted even after the note has been typed in", async ({ page }) => {
+    // Regression: the autosave debounce ref was assigned but never cleared, so
+    // from the first keystroke onward it stayed truthy forever — and the cache
+    // subscription that adopts externally-written content is gated on exactly
+    // that ref. The editor kept showing the pre-merge body, and the next
+    // keystroke saved that stale body back over the merged text. The source
+    // note is deleted by then, so the merged-in content was gone for good.
+    await signupFreshUser(page, "notemenu-merge-dirty");
+    await createNoteViaApi(page, "Dirty target", "first body\n");
+    await createNoteViaApi(page, "Dirty source", "merged-in body\n");
+    await page.reload();
+    await openNoteFromExplorer(page, "Dirty target");
+
+    // One keystroke, then let the 700ms debounce fire and the save land.
+    await editorSurface(page).click();
+    await page.keyboard.type("X");
+    await expect(editorSurface(page)).toContainText("X");
+    await page.waitForTimeout(1500);
+
+    const menu = await openNoteMenu(page);
+    await menu.getByRole("menuitem", { name: "Merge entire file with…", exact: true }).click();
+    await page.getByRole("dialog").getByRole("button", { name: "Dirty source", exact: true }).click();
+
+    await expect(editorSurface(page)).toContainText("merged-in body");
+
+    // And it must survive: typing again previously resubmitted the stale
+    // pre-merge draft, and the 409 retry path pushed it through.
+    await editorSurface(page).click();
+    await page.keyboard.type("Y");
+    await page.waitForTimeout(1500);
+    await page.reload();
+    await openNoteFromExplorer(page, "Dirty target");
+    await expect(editorSurface(page)).toContainText("merged-in body");
+  });
+
   test("merge appends the other note and deletes it", async ({ page }) => {
     await signupFreshUser(page, "notemenu-merge");
     await createNoteViaApi(page, "Merge target", "first body\n");

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -30,7 +30,7 @@
         "lucide": "^1.31.0",
         "lucide-react": "^1.31.0",
         "mermaid": "^11.16.1",
-        "next": "16.3.0",
+        "next": "16.3.1",
         "radix-ui": "^1.6.7",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -52,13 +52,13 @@
       "devDependencies": {
         "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
+        "@types/node": "^22.20.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "eslint": "^9",
-        "eslint-config-next": "16.3.0",
+        "eslint": "^9.39.5",
+        "eslint-config-next": "16.3.1",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@cosmos.gl/graph": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@cosmos.gl/graph/-/graph-3.4.0.tgz",
-      "integrity": "sha512-qxpkXKIVxy7F/ulE5LSfFU3dP3DLsMijnXI7OwmNamDwHrSFPm4yMhCdVBDkj7RTAeRO4k7bAO6FLeVSwBZSeQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@cosmos.gl/graph/-/graph-3.4.1.tgz",
+      "integrity": "sha512-dPbc2g+Hbu2djVjd7fkMqth8lvcjzFM1/byCbzF45kqkRAx7snMm0zifPR3xFL+THVHfy3x4Ep9uuQgPaxrQDg==",
       "license": "MIT",
       "dependencies": {
         "@luma.gl/core": "~9.3.6",
@@ -706,14 +706,14 @@
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1",
         "d3-zoom": "^3.0.0",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.4.13",
         "gl-bench": "^1.0.42",
         "gl-matrix": "^3.4.3",
         "random": "^4.1.0"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -764,6 +764,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@dotenvx/dotenvx/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@dotenvx/dotenvx/node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -785,23 +797,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/@dotenvx/dotenvx/node_modules/get-stream": {
@@ -900,18 +895,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@dotenvx/dotenvx/node_modules/signal-exit": {
@@ -1040,6 +1023,37 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
@@ -1088,6 +1102,37 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -1166,9 +1211,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
-      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -2099,9 +2144,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
-      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2116,20 +2161,20 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
-        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
     "node_modules/@next/env": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
-      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.1.tgz",
+      "integrity": "sha512-35G3xwkQUb2oETSDjFXGrVugknoayLFBh7vSE+yAcl9IP2zT9wyGwq7297AYHR11kJld807t5f8AJBs6WBzXsQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.0.tgz",
-      "integrity": "sha512-OqgJ8PN0d04KcPhDX/PTY5tJUJZxlbrt7O7FBsm4XE0XW2JDrKnDXsc9uo9WUimJGPoo2j+JRGhyXApC//mvbw==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.1.tgz",
+      "integrity": "sha512-B4SznlXwVpaLDa7Tbi6zLuueria2d/PmFDhXyDymPGrk2r1n/RMJmcn5FZq1L64k+Jsyte1lKvOr7lP9Xo80mQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2170,9 +2215,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
-      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.1.tgz",
+      "integrity": "sha512-ABMIu2zQ7cnNIHm5ivKGwZwUrm0pAai3yiJ/gK/rF1c1VP9UOnj7XECbMKFdVKp9I9eMYq9NoDs1WXOoowxzJw==",
       "cpu": [
         "arm64"
       ],
@@ -2186,9 +2231,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
-      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.1.tgz",
+      "integrity": "sha512-gNG21e/UnrroeScbY/QndUEdl0mF1FRibW7BBeYUz/5ABCepjqDdEdgr592vpzMtCn/m7FTjYq3TN4TpyDnutw==",
       "cpu": [
         "x64"
       ],
@@ -2202,9 +2247,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
-      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.1.tgz",
+      "integrity": "sha512-6B6Lw016iwNUQuaJoraMMTLh6TwHzFUtxipSScD1F3YyymcrRWkobodRS2ftIOkF5vrs4zNlyUrTC5YZQ9Lz5w==",
       "cpu": [
         "arm64"
       ],
@@ -2221,9 +2266,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
-      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.1.tgz",
+      "integrity": "sha512-JUiPXZKK9wOhjf4MgDiH29GZLxfqOesbLtHq2pDxwH/WwscTRV2ToymnOTh1egzaZf0ueUf8T2+CeYTGHjW0Iw==",
       "cpu": [
         "arm64"
       ],
@@ -2240,9 +2285,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
-      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.1.tgz",
+      "integrity": "sha512-Uog9jsrmIRIL/lfvIp9htmskSNC7JcQsMVucXL2V2YY1y/D9IUN3LPEafqy0zRJ2cIU1SQ0V6F6TlffQ+pLAGg==",
       "cpu": [
         "x64"
       ],
@@ -2259,9 +2304,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
-      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.1.tgz",
+      "integrity": "sha512-6yy3FT13KgUFOj5H8bl8w/6nKiJwHIvbtwh1V+1acsu+7y4tJjnemSa6mhsh53BeoVrlozE+fMgZhXH46WmjMA==",
       "cpu": [
         "x64"
       ],
@@ -2278,9 +2323,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
-      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.1.tgz",
+      "integrity": "sha512-iOoN1QecUoGNZik536U/vtK43YwgyrCsGIkth52yIkl612n+0C9MjSnJbQAikISpb+WYRooBVhaDlUW7iZoKog==",
       "cpu": [
         "arm64"
       ],
@@ -2294,9 +2339,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
-      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.1.tgz",
+      "integrity": "sha512-d/k+PpAriUPaeMJJOG7HUSdqfEX46FEPWU1p3/nm2ACmXhj9hFEWdFODUBIpkuijXYkfL90qZzTqVPRp4BW/hw==",
       "cpu": [
         "x64"
       ],
@@ -4026,35 +4071,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
@@ -4075,18 +4091,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4523,18 +4527,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@sentry/bundler-plugin-core/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/@sentry/bundler-plugins": {
       "version": "10.70.0",
       "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.70.0.tgz",
@@ -4563,6 +4555,18 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@sentry/cli": {
@@ -5068,9 +5072,9 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -5423,27 +5427,6 @@
         "path-browserify": "^1.0.1"
       }
     },
-    "node_modules/@ts-morph/common/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@ts-morph/common/node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5470,21 +5453,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -5825,9 +5793,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5877,92 +5845,6 @@
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
-      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/type-utils": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
-        "ignore": "^7.0.5",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.67.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
-      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
-      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.67.0",
-        "@typescript-eslint/types": "^8.67.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
@@ -5981,48 +5863,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
-      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
-      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
@@ -6035,110 +5875,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
-      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.67.0",
-        "@typescript-eslint/tsconfig-utils": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
-      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.67.0",
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -6157,19 +5893,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -7136,16 +6859,18 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
-      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "version": "2.11.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+      "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7179,9 +6904,9 @@
       }
     },
     "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7191,15 +6916,32 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7433,9 +7175,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
       "license": "MIT"
     },
     "node_modules/class-variance-authority": {
@@ -7545,12 +7287,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">= 12"
       }
     },
     "node_modules/commondir": {
@@ -8008,18 +7750,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/d3-ease": {
@@ -8624,9 +8354,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -8656,9 +8386,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.405",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
-      "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+      "version": "1.5.407",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.407.tgz",
+      "integrity": "sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -9035,13 +8765,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.3.0.tgz",
-      "integrity": "sha512-lPrf1kHsMJEZqO0uXkNB400c5MGrhrTk3BNX7P0ol4gt61+iUlQfjy9TyIOEA9eOXrf+5+mYbT/JsY8+zqUByQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.3.1.tgz",
+      "integrity": "sha512-0vtrpwFVHFEkycUgV/DyrG29OS+HSRdah5Yu8YuZoiBMtlAT6NIiWzaLwDkJZxr2kGfx+9LIvfQ7KHAlEs0VsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.3.0",
+        "@next/eslint-plugin-next": "16.3.1",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -9061,42 +8791,25 @@
         }
       }
     },
-    "node_modules/eslint-config-next/node_modules/globals": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
-      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+    "node_modules/eslint-config-next/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "MIT"
     },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
-      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+    "node_modules/eslint-config-next/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.16.1",
-        "resolve": "^2.0.0-next.6"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript": {
+    "node_modules/eslint-config-next/node_modules/eslint-import-resolver-typescript": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
       "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
@@ -9131,35 +8844,7 @@
         }
       }
     },
-    "node_modules/eslint-module-utils": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
-      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-import": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
@@ -9193,7 +8878,7 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
@@ -9203,7 +8888,7 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-jsx-a11y": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
@@ -9233,7 +8918,7 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-react": {
+    "node_modules/eslint-config-next/node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
@@ -9264,6 +8949,338 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.67.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/typescript-eslint/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -9304,6 +9321,37 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
@@ -9314,6 +9362,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -9327,6 +9388,19 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.2.1"
       },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -9626,6 +9700,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/figures": {
@@ -9969,9 +10060,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
-      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.2.tgz",
+      "integrity": "sha512-XpwZALwwl/BaKTAyC6+c5T8y6kCg2jk+XGqOVrKIQmW49pNypYLMRjCUXqa28tQgJlhS2RlzP7sc+Rx7W6qsfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10021,42 +10112,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -10413,9 +10468,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -10484,19 +10539,15 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -11317,9 +11368,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -11452,15 +11503,6 @@
       },
       "bin": {
         "katex": "cli.js"
-      }
-    },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/keyv": {
@@ -12391,15 +12433,6 @@
         "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
-    "node_modules/mermaid/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/mermaid/node_modules/katex": {
       "version": "0.16.47",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
@@ -12639,15 +12672,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-math/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/micromark-extension-math/node_modules/katex": {
@@ -13052,6 +13076,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -13099,16 +13135,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -13260,13 +13298,13 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
-      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.1.tgz",
+      "integrity": "sha512-hsAp0i7Rh+/dhe7DGIeN2YlpLM1DP4MNxti9EtDMtqcO612X81MvvEj388/oTce9U1EcEIOWDlGq0zRwrBKvuA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.3.0",
-        "@swc/helpers": "0.5.15",
+        "@next/env": "16.3.1",
+        "@swc/helpers": "0.5.23",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.5.23",
@@ -13279,14 +13317,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.3.0",
-        "@next/swc-darwin-x64": "16.3.0",
-        "@next/swc-linux-arm64-gnu": "16.3.0",
-        "@next/swc-linux-arm64-musl": "16.3.0",
-        "@next/swc-linux-x64-gnu": "16.3.0",
-        "@next/swc-linux-x64-musl": "16.3.0",
-        "@next/swc-win32-arm64-msvc": "16.3.0",
-        "@next/swc-win32-x64-msvc": "16.3.0",
+        "@next/swc-darwin-arm64": "16.3.1",
+        "@next/swc-darwin-x64": "16.3.1",
+        "@next/swc-linux-arm64-gnu": "16.3.1",
+        "@next/swc-linux-arm64-musl": "16.3.1",
+        "@next/swc-linux-x64-gnu": "16.3.1",
+        "@next/swc-linux-x64-musl": "16.3.1",
+        "@next/swc-win32-arm64-msvc": "16.3.1",
+        "@next/swc-win32-x64-msvc": "16.3.1",
         "sharp": "^0.35.3"
       },
       "peerDependencies": {
@@ -13609,17 +13647,17 @@
       }
     },
     "node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.1.tgz",
+      "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
         "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
+        "powershell-utils": "^0.2.0",
+        "wsl-utils": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -13670,9 +13708,9 @@
       }
     },
     "node_modules/ora/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13939,12 +13977,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -14132,9 +14170,9 @@
       }
     },
     "node_modules/powershell-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -14403,6 +14441,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -14628,15 +14682,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/rehype-katex/node_modules/katex": {
@@ -15243,9 +15288,9 @@
       "license": "ISC"
     },
     "node_modules/shadcn": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.17.0.tgz",
-      "integrity": "sha512-kphndh72CD7mxLQ/thkbPVgfXpIjzPUllzvTWRJmU3sNGZc/WbOqzJ0FXbBGj6sqNiaGPiOLDQByy8FAtCuVUQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.18.0.tgz",
+      "integrity": "sha512-tUFZgkYmfVNQVm3xX7lhSzOvDsp+O14ac5dwgXIr5mIsr79ISueb/Mu+ZtWMz0DH6v77u4eYyvbQ9TTMpSn3aw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -15287,6 +15332,15 @@
       },
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/shadcn/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/shadcn/node_modules/fast-glob": {
@@ -15668,9 +15722,9 @@
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16096,37 +16150,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -16288,9 +16311,9 @@
       }
     },
     "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16379,9 +16402,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16390,30 +16413,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript-eslint": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
-      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.67.0",
-        "@typescript-eslint/parser": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -17039,14 +17038,26 @@
       "license": "ISC"
     },
     "node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
       "license": "MIT",
       "dependencies": {
         "is-wsl": "^3.1.0",
         "powershell-utils": "^0.1.0"
       },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
       "engines": {
         "node": ">=20"
       },
@@ -17207,9 +17218,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
-      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.15.tgz",
+      "integrity": "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,7 @@
     "lucide": "^1.31.0",
     "lucide-react": "^1.31.0",
     "mermaid": "^11.16.1",
-    "next": "16.3.0",
+    "next": "16.3.1",
     "radix-ui": "^1.6.7",
     "react": "19.2.8",
     "react-dom": "19.2.8",
@@ -54,12 +54,12 @@
   "devDependencies": {
     "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "^22.20.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "16.3.0",
+    "eslint": "^9.39.5",
+    "eslint-config-next": "16.3.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   }
 }

--- a/web/src/components/workspace/editor-pane.tsx
+++ b/web/src/components/workspace/editor-pane.tsx
@@ -95,6 +95,11 @@ function EditorBody({ vaultId, note, paneIndex }: { vaultId: string; note: Note;
   const [editorEpoch, setEditorEpoch] = useState(0);
   const baseUpdatedAt = useRef(note.updated_at);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The body we know is on the server. `draftRef !== lastSavedRef` is the
+  // "there are unsaved keystrokes" test — including the window after the
+  // debounce fires but before the save lands, which the timer ref alone cannot
+  // express.
+  const lastSavedRef = useRef(note.content);
   const conflictRetries = useRef(0);
 
   // ── Live collaboration (per-vault opt-in via settings.collabEnabled) ──────
@@ -180,6 +185,7 @@ function EditorBody({ vaultId, note, paneIndex }: { vaultId: string; note: Note;
     onSuccess: (saved: Note) => {
       conflictRetries.current = 0;
       baseUpdatedAt.current = saved.updated_at;
+      lastSavedRef.current = draftRef.current;
       queryClient.setQueryData(["note", vaultId, note.id], { ...saved, content: draftRef.current });
       void queryClient.invalidateQueries({ queryKey: ["backlinks", vaultId] });
       void queryClient.invalidateQueries({ queryKey: ["outgoing", vaultId] });
@@ -193,7 +199,12 @@ function EditorBody({ vaultId, note, paneIndex }: { vaultId: string; note: Note;
       if (err instanceof ApiError && err.status === 409 && conflictRetries.current < 2) {
         conflictRetries.current += 1;
         const details = err.details as { server_updated_at?: string } | undefined;
-        if (details?.server_updated_at) {
+        // Only resubmit when there is something of the user's to resubmit.
+        // Retrying a draft identical to what we already persisted just
+        // overwrites whatever the other writer put there with a body the user
+        // never edited — which is how a merge or template insert got silently
+        // reverted.
+        if (details?.server_updated_at && draftRef.current !== lastSavedRef.current) {
           baseUpdatedAt.current = details.server_updated_at;
           save.mutate(draftRef.current);
           return;
@@ -210,8 +221,17 @@ function EditorBody({ vaultId, note, paneIndex }: { vaultId: string; note: Note;
       // Only a LIVE collab session persists on our behalf; a session that never
       // connected must still autosave over REST or the work is lost.
       if (collabLiveRef.current) return;
-      if (saveTimer.current) clearTimeout(saveTimer.current);
-      saveTimer.current = setTimeout(() => save.mutate(content), 700);
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+        saveTimer.current = null;
+      }
+      // Nulling the ref inside the callback is what makes the external-write
+      // adoption below work at all: it is gated on `saveTimer.current === null`,
+      // and this ref used to stay truthy forever after the first keystroke.
+      saveTimer.current = setTimeout(() => {
+        saveTimer.current = null;
+        save.mutate(content);
+      }, 700);
     },
     [save],
   );
@@ -228,8 +248,17 @@ function EditorBody({ vaultId, note, paneIndex }: { vaultId: string; note: Note;
       // text would otherwise leave the node breathing forever. Only clear our
       // own claim; the other pane may have taken over already.
       if (currentActiveNote() === note.id) setActiveNote(null);
-      if (saveTimer.current && !collabLiveRef.current) {
-        clearTimeout(saveTimer.current);
+      // Gate on the draft actually differing from what was persisted, not on
+      // the timer alone. The timer ref used to never clear, so this fired a
+      // second redundant saveContent on every tab close even when the debounced
+      // save had already succeeded — racing it, with a now-stale base timestamp.
+      if (
+        !collabLiveRef.current &&
+        draftRef.current !== lastSavedRef.current &&
+        (saveTimer.current !== null || draftRef.current !== note.content)
+      ) {
+        if (saveTimer.current) clearTimeout(saveTimer.current);
+        saveTimer.current = null;
         void noteApi.saveContent(vaultId, note.id, draftRef.current, baseUpdatedAt.current);
       }
     };
@@ -262,8 +291,17 @@ function EditorBody({ vaultId, note, paneIndex }: { vaultId: string; note: Note;
       if (next === undefined || next === draftRef.current) return;
       // Never clobber unsaved keystrokes, and stay out of collab's way — a live
       // room already receives external writes through its own reset channel.
-      if (saveTimer.current !== null || collabLiveRef.current) return;
+      // The second clause covers the in-flight window: between the debounce
+      // firing and onSuccess landing there is no timer, but the draft is not
+      // persisted yet either.
+      if (
+        saveTimer.current !== null ||
+        draftRef.current !== lastSavedRef.current ||
+        collabLiveRef.current
+      )
+        return;
       draftRef.current = next;
+      lastSavedRef.current = next;
       setDraft(next);
       baseUpdatedAt.current = (event.query.state.data as Note).updated_at;
       // Remount CodeMirror: its document is independent of `draft` after mount.
@@ -461,7 +499,11 @@ function EditorBody({ vaultId, note, paneIndex }: { vaultId: string; note: Note;
         onOpenChange={setVersionsOpen}
         onRestored={(restored) => {
           if (saveTimer.current) clearTimeout(saveTimer.current);
+          saveTimer.current = null;
           draftRef.current = restored.content;
+          // Without this the pane looks permanently dirty and would refuse
+          // every subsequent external write for the rest of its life.
+          lastSavedRef.current = restored.content;
           setDraft(restored.content);
           baseUpdatedAt.current = restored.updated_at;
           setEditorEpoch((n) => n + 1);

--- a/web/src/components/workspace/sidebar-right.tsx
+++ b/web/src/components/workspace/sidebar-right.tsx
@@ -213,12 +213,10 @@ function OutgoingPane({
   vaultId,
   noteId,
   onOpenNote,
-  drawer = false,
 }: {
   vaultId: string;
   noteId: string | null;
   onOpenNote: (noteId: string, title: string) => void;
-  drawer?: boolean;
 }) {
   const { data } = useQuery({
     queryKey: ["outgoing", vaultId, noteId],
@@ -392,12 +390,10 @@ function LocalGraphPane({
   vaultId,
   noteId,
   onOpenNote,
-  drawer = false,
 }: {
   vaultId: string;
   noteId: string | null;
   onOpenNote: (noteId: string, title: string) => void;
-  drawer?: boolean;
 }) {
   const [depth, setDepth] = useState(1);
 

--- a/web/src/lib/editor/block-widgets.ts
+++ b/web/src/lib/editor/block-widgets.ts
@@ -16,7 +16,6 @@ import type { DecorationSet } from "@codemirror/view";
 import { Decoration, EditorView, WidgetType } from "@codemirror/view";
 
 import { renderMathHTML } from "./math";
-import { renderCellHTML, splitRow } from "./table-model";
 import { EditableTableWidget } from "./table-widget";
 import { renderMermaidSvg } from "./mermaid";
 import { cachedHighlight, highlightToHtml } from "./shiki";
@@ -27,49 +26,6 @@ function selectionTouches(state: EditorState, from: number, to: number): boolean
 
 // ── Table widget ─────────────────────────────────────────────────────────────
 
-/** Minimal inline-markdown for table cells: bold/italic/code/strike as text styling. */
-
-
-class TableWidget extends WidgetType {
-  constructor(readonly source: string) {
-    super();
-  }
-
-  override eq(other: TableWidget): boolean {
-    return other.source === this.source;
-  }
-
-  override toDOM(): HTMLElement {
-    const lines = this.source
-      .split("\n")
-      .map((l) => l.trim())
-      .filter((l) => l.startsWith("|") || l.includes("|"));
-    // Shared with table-commands.ts: if the widget and the commands split
-    // differently, the column you click is not the column they edit.
-    const parseRow = (line: string): string[] => splitRow(line);
-
-    const wrap = document.createElement("div");
-    wrap.className = "cm-table-widget";
-    const table = document.createElement("table");
-    wrap.appendChild(table);
-
-    lines.forEach((line, i) => {
-      if (i === 1 && /^[\s|:-]+$/.test(line)) return; // separator row
-      const tr = document.createElement("tr");
-      for (const cell of parseRow(line)) {
-        const td = document.createElement(i === 0 ? "th" : "td");
-        td.innerHTML = renderCellHTML(cell);
-        tr.appendChild(td);
-      }
-      table.appendChild(tr);
-    });
-    return wrap;
-  }
-
-  override ignoreEvent(): boolean {
-    return false; // click → cursor enters the region → raw syntax reveals
-  }
-}
 
 // ── Properties (frontmatter) widget — field-level editing ────────────────────
 

--- a/web/src/lib/editor/table-widget.ts
+++ b/web/src/lib/editor/table-widget.ts
@@ -103,7 +103,10 @@ function setCaretOffset(cell: HTMLElement, offset: number): void {
   const max = node.nodeType === Node.TEXT_NODE ? (node.textContent ?? "").length : 0;
   const range = doc.createRange();
   if (node.nodeType === Node.TEXT_NODE) range.setStart(node, Math.min(offset, max));
-  else range.selectNodeContents(cell), range.collapse(false);
+  // An empty cell has no text node to offset into, so anchor to its contents.
+  // The comma-operator `range.collapse(false)` that used to live here was dead:
+  // the unconditional collapse(true) below immediately overrode it.
+  else range.selectNodeContents(cell);
   range.collapse(true);
   sel.removeAllRanges();
   sel.addRange(range);


### PR DESCRIPTION
Stacked on #4. Four commits: new CI workflows, an editor data-loss fix, and backend query work — all from the verified audit findings.

## New workflows, and what they immediately caught

**Added**: Security (pip-audit + npm audit + dependency review), CodeQL, Docker (build + Trivy + compose validation), Dependabot. CodeQL and dependency-review are gated on repo visibility — both need Advanced Security, which a private repo on a free plan lacks, so ungated they'd fail forever. They switch on when the repo goes public.

On their first run they found:

- **`./compose.sh test up` was broken outright.** `docker-compose.test.yml` added a `tmpfs` at `/var/lib/postgresql/data` while the base file mounts a named volume at the same target; Compose merges rather than overrides, so the whole test environment failed to render. `make test-up` had not worked.
- **The API production image shipped `build-essential` and `libpq-dev`** — every OS-level CVE in it. Nothing at runtime links libpq (asyncpg speaks the wire protocol itself). Production now builds from a clean base: **248 MB → 127 MB**, and the `chown -R` that duplicated the ~160 MB virtualenv into a second layer is gone.
- **Stripped `pip` from the API runtime and `npm` from the web runtime.** Neither is used, and both carry vendored trees no dependency update of ours could ever clear — pip's vendored msgpack, npm's brace-expansion/tar/picomatch/sigstore. Both images now scan **0 fixable HIGH/CRITICAL**.

## Editor: silently losing merged content

The autosave debounce ref was assigned but never cleared, so from the first keystroke it stayed truthy forever — and the subscription that adopts externally-written content is gated on exactly that ref. Type one character, then "Merge entire file with…": the editor keeps the pre-merge body, the next keystroke saves it back with a stale timestamp, the 409 handler adopts the server timestamp and resubmits the stale draft. The source note is already deleted, so the merged text is gone permanently.

Fixed by nulling the ref everywhere and tracking `lastSavedRef` (the body known to be on the server), which also covers the in-flight window the timer can't express. Pinned by an e2e test that types before merging — the existing merge test passes either way, because a never-typed-in pane has a null timer.

## Query performance

- **Backlinks** selected `Note.content` over every link pointing at the note and capped in Python *after* Postgres returned every row. A hub note transferred thousands of bodies to render a 200-entry panel, on every note switch. Now two queries, capped in SQL, title-ordered so truncation stays deterministic.
- **Related notes**: bounded with `statement_timeout`. Deliberately *not* an ANN index — pgvector post-filters HNSW, so a table-wide index on a `vault_id`-filtered query returns the globally-nearest vectors and only then applies the tenant filter, silently handing back wrong results.
- **Argon2id moved off the event loop.** 22 ms of solid CPU on every login blocked every other request on the worker; measured, the loop now ticks 21× during a hash instead of 0.

## Verification

47 unit + 100 integration tests green, ruff clean, tsc clean, eslint 0 errors, both images build and smoke-test, all three compose environments render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)