### PR TITLE
feat(deploy): support a managed object store, not just the bundled MinIO

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,18 @@ jobs:
             ./compose.sh "$env" config --quiet
           done
 
+          # The managed-object-store path takes a different set of compose
+          # files, so render it too — and assert it really drops MinIO, which
+          # is the whole point of the override.
+          echo "── prod, external object store ──"
+          printf 'S3_ENDPOINT_URL=https://example.invalid\nS3_ACCESS_KEY=k\nS3_SECRET_KEY=s\n' >> .env.prod
+          sed -i 's|^S3_PUBLIC_URL=.*|S3_PUBLIC_URL=https://example.invalid|' .env.prod
+          ./compose.sh prod config --quiet
+          if ./compose.sh prod config --services | grep -qx minio; then
+            echo "::error::external-S3 override did not remove the minio service"; exit 1
+          fi
+          echo "minio correctly absent"
+
       # The proxy config is the one file compose cannot check for us, and a
       # broken Caddyfile takes the whole site down rather than one service.
       - name: Validate the Caddyfile

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -78,7 +78,30 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
+
+      # The action hard-fails with "Dependency review is not supported on this
+      # repository" when the dependency graph is off — a repo setting, not
+      # anything about the code. Probing the same endpoint it uses lets the job
+      # skip cleanly instead of sitting permanently red, and it starts working
+      # by itself the moment the graph is enabled, with no workflow change.
+      - name: Is the dependency graph available?
+        id: depgraph
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/dependency-graph/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
+          if [ "$code" = "200" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Dependency graph unavailable (HTTP $code). Enable it under Settings → Code security → Dependency graph; this job will start running on its own."
+          fi
+
       - uses: actions/dependency-review-action@v5.0.0
+        if: steps.depgraph.outputs.available == 'true'
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -42,11 +42,6 @@ NODUM_HTTPS_PORT=443
 FRONTEND_BASE_URL=https://nodum.example.com
 BACKEND_CORS_ORIGINS=https://nodum.example.com
 
-# Where the browser fetches attachments. Attachments are served straight from
-# MinIO over presigned URLs, and Caddy proxies them at /s3 — so this is your
-# own origin with /s3 on the end, NOT a MinIO host/port.
-# Getting this wrong shows up as broken images, not as an error at boot.
-S3_PUBLIC_URL=https://nodum.example.com/s3
 
 # ── Secrets ─────────────────────────────────────────────────
 SECRET_KEY=
@@ -57,9 +52,44 @@ POSTGRES_USER=nodum
 POSTGRES_PASSWORD=
 POSTGRES_DB=nodum
 
-# ── MinIO (attachment storage) ──────────────────────────────
+# ── Object storage (attachments) ────────────────────────────
+# Pick ONE of the two blocks below.
+#
+# Attachments are handed to the browser as presigned URLs either way. What
+# differs is who serves the bytes — and getting S3_PUBLIC_URL wrong shows up as
+# broken images, never as an error at boot.
+
+# ── Option A: bundled MinIO (default, self-contained) ───────
+# Runs in the stack; Caddy proxies it at /s3. S3_PUBLIC_URL is therefore your
+# own origin with /s3 on the end, NOT a MinIO host and port. You own the
+# backups for it (docs/backup.md).
+S3_PUBLIC_URL=https://nodum.example.com/s3
 MINIO_ROOT_USER=nodum
 MINIO_ROOT_PASSWORD=
+
+# ── Option B: a managed store ───────────────────────────────
+# Set S3_ENDPOINT_URL and compose.sh drops MinIO, its volume and its memory
+# budget from the stack — on a small host, the biggest simplification available,
+# and the provider handles durability. Works with Hetzner Object Storage, AWS
+# S3, Cloudflare R2, Backblaze B2, or any S3-compatible endpoint.
+#
+# S3_PUBLIC_URL must EQUAL S3_ENDPOINT_URL here: the presigned URL is already
+# public, so nothing rewrites it. Delete the Option A lines above if you use
+# this, and note the /s3 Caddy route simply goes unused.
+#
+# S3_REGION is not cosmetic — SigV4 signs it, so a wrong value fails every
+# request with SignatureDoesNotMatch. Hetzner uses the location code (fsn1,
+# nbg1, hel1); AWS uses eu-central-1 etc.; R2 uses auto.
+#
+# No bucket CORS is needed: attachments only ever land in an <img>/<iframe>
+# src attribute, never in a fetch().
+#
+# S3_ENDPOINT_URL=https://fsn1.your-objectstorage.com
+# S3_PUBLIC_URL=https://fsn1.your-objectstorage.com
+# S3_BUCKET_NAME=nodum
+# S3_REGION=fsn1
+# S3_ACCESS_KEY=
+# S3_SECRET_KEY=
 
 # ── AI (bring your own key) ─────────────────────────────────
 # Empty turns the AI feature off entirely. Rotating this makes every stored

--- a/deploy/.env.staging.example
+++ b/deploy/.env.staging.example
@@ -34,8 +34,6 @@ NODUM_HTTPS_PORT=8443
 # than through a load balancer on the standard ports.
 FRONTEND_BASE_URL=https://staging.nodum.example.com
 BACKEND_CORS_ORIGINS=https://staging.nodum.example.com
-# Your own origin with /s3 — Caddy proxies presigned attachment URLs there.
-S3_PUBLIC_URL=https://staging.nodum.example.com/s3
 
 # ── Secrets (distinct from production) ──────────────────────
 SECRET_KEY=
@@ -46,9 +44,44 @@ POSTGRES_USER=nodum
 POSTGRES_PASSWORD=
 POSTGRES_DB=nodum
 
-# ── MinIO (attachment storage) ──────────────────────────────
+# ── Object storage (attachments) ────────────────────────────
+# Pick ONE of the two blocks below.
+#
+# Attachments are handed to the browser as presigned URLs either way. What
+# differs is who serves the bytes — and getting S3_PUBLIC_URL wrong shows up as
+# broken images, never as an error at boot.
+
+# ── Option A: bundled MinIO (default, self-contained) ───────
+# Runs in the stack; Caddy proxies it at /s3. S3_PUBLIC_URL is therefore your
+# own origin with /s3 on the end, NOT a MinIO host and port. You own the
+# backups for it (docs/backup.md).
+S3_PUBLIC_URL=https://staging.nodum.example.com/s3
 MINIO_ROOT_USER=nodum
 MINIO_ROOT_PASSWORD=
+
+# ── Option B: a managed store ───────────────────────────────
+# Set S3_ENDPOINT_URL and compose.sh drops MinIO, its volume and its memory
+# budget from the stack — on a small host, the biggest simplification available,
+# and the provider handles durability. Works with Hetzner Object Storage, AWS
+# S3, Cloudflare R2, Backblaze B2, or any S3-compatible endpoint.
+#
+# S3_PUBLIC_URL must EQUAL S3_ENDPOINT_URL here: the presigned URL is already
+# public, so nothing rewrites it. Delete the Option A lines above if you use
+# this, and note the /s3 Caddy route simply goes unused.
+#
+# S3_REGION is not cosmetic — SigV4 signs it, so a wrong value fails every
+# request with SignatureDoesNotMatch. Hetzner uses the location code (fsn1,
+# nbg1, hel1); AWS uses eu-central-1 etc.; R2 uses auto.
+#
+# No bucket CORS is needed: attachments only ever land in an <img>/<iframe>
+# src attribute, never in a fetch().
+#
+# S3_ENDPOINT_URL=https://fsn1.your-objectstorage.com
+# S3_PUBLIC_URL=https://fsn1.your-objectstorage.com
+# S3_BUCKET_NAME=nodum
+# S3_REGION=fsn1
+# S3_ACCESS_KEY=
+# S3_SECRET_KEY=
 
 # ── AI (bring your own key) ─────────────────────────────────
 AI_ENCRYPTION_KEY=

--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -78,6 +78,24 @@ run() {
     "${ENGINE[@]}" --env-file "$env_file" "${files[@]}" --project-name "$project" "${ARGS[@]}"
 }
 
+# A non-empty S3_ENDPOINT_URL means attachments live in a managed store, so the
+# bundled MinIO is dead weight. Read from the file rather than the environment:
+# the file is the single source of truth for what this deployment is, and a
+# stray exported variable in someone's shell must not silently change which
+# services get started.
+uses_external_s3() {
+    grep -qE '^[[:space:]]*S3_ENDPOINT_URL[[:space:]]*=[[:space:]]*[^[:space:]#]' "$env_file"
+}
+
+# Assemble the file list for a deployment environment, adding the external-S3
+# override only when it applies. Fills the FILES array rather than echoing, so
+# nothing depends on word splitting.
+FILES=()
+collect_deploy_files() {
+    FILES=(docker-compose.yml docker-compose.deploy.yml "$1")
+    if uses_external_s3; then FILES+=(docker-compose.external-s3.yml); fi
+}
+
 ARGS=("$@")
 
 case "$ENV" in
@@ -94,12 +112,14 @@ case "$ENV" in
     staging)
         resolve_env_file staging
         export NODUM_ENVIRONMENT=staging NODUM_IMAGE_TAG="${NODUM_IMAGE_TAG:-staging}"
-        run nodum-staging docker-compose.yml docker-compose.deploy.yml docker-compose.staging.yml
+        collect_deploy_files docker-compose.staging.yml
+        run nodum-staging "${FILES[@]}"
         ;;
     prod)
         resolve_env_file prod
         export NODUM_ENVIRONMENT=production NODUM_IMAGE_TAG="${NODUM_IMAGE_TAG:-prod}"
-        run nodum-prod docker-compose.yml docker-compose.deploy.yml docker-compose.prod.yml
+        collect_deploy_files docker-compose.prod.yml
+        run nodum-prod "${FILES[@]}"
         ;;
     *)
         echo "Usage: $0 {dev|test|staging|prod} [compose args...]" >&2

--- a/deploy/docker-compose.deploy.yml
+++ b/deploy/docker-compose.deploy.yml
@@ -53,10 +53,24 @@ x-backend-env: &backend-env
   REDIS_CONTROL_URL: redis://redis-control:6379/0
   CELERY_BROKER_URL: redis://redis:6379/1
   CELERY_RESULT_BACKEND: redis://redis:6379/2
-  S3_ENDPOINT_URL: http://minio:9000
+  # Object storage. Defaults to the bundled MinIO; set S3_ENDPOINT_URL to a
+  # managed store (Hetzner, AWS, R2, Backblaze) and compose.sh drops the MinIO
+  # container, its volume and its memory budget from the stack entirely.
+  #
+  # S3_PUBLIC_URL is what the browser is sent to. With the bundled MinIO that
+  # is your own origin + /s3, which Caddy proxies. With a managed store it must
+  # equal S3_ENDPOINT_URL — the presigned URL is then already public, and the
+  # rewrite in attachment_service is skipped.
+  S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
   S3_PUBLIC_URL: ${S3_PUBLIC_URL:?set in your env file}
-  S3_ACCESS_KEY: ${MINIO_ROOT_USER:?set in your env file}
-  S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?set in your env file}
+  # Fall back to the MinIO root credentials so the bundled path needs no
+  # duplication, while a managed store just sets its own keys.
+  S3_ACCESS_KEY: ${S3_ACCESS_KEY:-${MINIO_ROOT_USER:-}}
+  S3_SECRET_KEY: ${S3_SECRET_KEY:-${MINIO_ROOT_PASSWORD:-}}
+  S3_BUCKET_NAME: ${S3_BUCKET_NAME:-nodum}
+  # Signing region. MinIO ignores it; a managed store does not — SigV4 covers
+  # the region, so the wrong value fails every request with SignatureDoesNotMatch.
+  S3_REGION: ${S3_REGION:-us-east-1}
   SECRET_KEY: ${SECRET_KEY:?set in your env file}
   JWT_SECRET_KEY: ${JWT_SECRET_KEY:?set in your env file}
   # Empty disables bring-your-own-key AI entirely.

--- a/deploy/docker-compose.external-s3.yml
+++ b/deploy/docker-compose.external-s3.yml
@@ -1,0 +1,47 @@
+# ============================================================
+# External object storage
+# ============================================================
+# Layered in automatically by compose.sh whenever the environment file sets a
+# non-empty S3_ENDPOINT_URL — i.e. when attachments live in a managed store
+# (Hetzner Object Storage, AWS S3, Cloudflare R2, Backblaze B2) rather than in
+# the bundled MinIO.
+#
+# What it does: takes MinIO out of the stack, and out of everything that waited
+# on it. That removes a stateful service, its volume, its memory budget and its
+# place in your backup plan — on a small host, the single biggest simplification
+# available.
+#
+# What you give up: nothing the application needs. Attachments are handed to the
+# browser as presigned URLs either way; with a managed store those URLs are
+# already public, so the /s3 route in the Caddyfile simply stops being used.
+# ============================================================
+
+services:
+  # An unreferenced profile is how a service gets excluded: nothing activates
+  # "bundled-s3", so MinIO is never created. Compose would otherwise pull the
+  # profile in automatically on behalf of anything that depends_on it — which
+  # is exactly why the dependencies below have to go too.
+  minio:
+    profiles: ["bundled-s3"]
+
+  api:
+    depends_on: !override
+      migrate:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      redis-control:
+        condition: service_healthy
+    networks: !override
+      - app_network
+      - edge
+
+  caddy:
+    # Nothing generates /s3 URLs when the store is external, so the route in the
+    # Caddyfile is dead rather than broken. Caddy dials upstreams lazily, so an
+    # absent `minio` host costs nothing until something requests it.
+    depends_on: !override
+      web:
+        condition: service_healthy

--- a/deploy/smoke.sh
+++ b/deploy/smoke.sh
@@ -51,23 +51,29 @@ echo "$g" | grep -q '"nodes"' && ok "graph (redis cache path)" || bad "graph fai
 printf 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==' | base64 -d > /tmp/smoke.png
 up=$(curl -s -X POST "$BASE/api/v1/vaults/$VAULT/attachments" -H "$AUTH" -F "file=@/tmp/smoke.png;type=image/png")
 AID=$(printf '%s' "$up" | python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["id"])' 2>/dev/null)
-[ -n "$AID" ] && ok "attachment uploaded to MinIO ($AID)" || { bad "upload failed: ${up:0:250}"; exit 1; }
+[ -n "$AID" ] && ok "attachment uploaded to object storage ($AID)" || { bad "upload failed: ${up:0:250}"; exit 1; }
 
 URL=$(curl -s "$BASE/api/v1/vaults/$VAULT/attachments/$AID/url" -H "$AUTH" \
       | python3 -c 'import json,sys; d=json.load(sys.stdin)["data"]; print(d["url"] if isinstance(d,dict) else d)' 2>/dev/null)
 echo "    presigned: ${URL:0:80}..."
 case "$URL" in
-  "$BASE"/s3/*) ok "presigned URL points at the public /s3 route" ;;
-  *) bad "presigned URL is not proxied: $URL" ;;
+  "$BASE"/s3/*)
+    ok "presigned URL points at the bundled MinIO via the /s3 route" ;;
+  http://*|https://*)
+    # A managed store (Hetzner, S3, R2) presigns its own public endpoint, so
+    # the URL is off-origin by design and nothing proxies it.
+    ok "presigned URL points at an external object store" ;;
+  *)
+    bad "presigned URL is not absolute: $URL" ;;
 esac
 
 # -o, not stdout capture: the payload is binary and shell/sed mangle it.
 dlcode=$(curl -s -o /tmp/smoke-dl.png -w '%{http_code}' "$URL")
 if [ "$dlcode" = 200 ]; then
-  if cmp -s /tmp/smoke.png /tmp/smoke-dl.png; then ok "attachment downloaded through /s3, bytes identical"
+  if cmp -s /tmp/smoke.png /tmp/smoke-dl.png; then ok "attachment downloaded from its presigned URL, bytes identical"
   else bad "attachment bytes differ ($(wc -c </tmp/smoke.png) sent vs $(wc -c </tmp/smoke-dl.png) received)"; fi
 else
-  bad "attachment download returned $dlcode (SigV4 covers Host+path — check the /s3 route)"
+  bad "attachment download returned $dlcode (SigV4 covers Host+path — check the /s3 route, or S3_REGION for a managed store)"
 fi
 
 echo

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -54,11 +54,51 @@ Three values decide whether the deployment works at all:
 |---|---|---|
 | `NODUM_SITE_ADDRESS` | `nodum.example.com` | A bare hostname makes Caddy obtain and renew TLS itself. `:80` serves plain HTTP with no ACME — only correct behind another terminator |
 | `FRONTEND_BASE_URL` | `https://nodum.example.com` | This is the origin the browser is sent back to after Google sign-in, and the CORS origin. Point it at the API and login lands on a 404 |
-| `S3_PUBLIC_URL` | `https://nodum.example.com/s3` | Your own origin with `/s3`, **not** a MinIO host. Attachments are presigned URLs that Caddy proxies there. Wrong value = broken images, with no error at boot |
+| `S3_PUBLIC_URL` | see below | Where the browser fetches attachments. Wrong value = broken images, with no error at boot |
 
 The API refuses to start on placeholder or known-default credentials
 (`back/app/settings/production.py`). That is a backstop, not a substitute for
 reading the file.
+
+### Object storage
+
+Attachments go to S3. Pick one:
+
+**Bundled MinIO** (default, self-contained). Runs in the stack, Caddy serves it
+at `/s3`, and you own its backups:
+
+```ini
+S3_PUBLIC_URL=https://nodum.example.com/s3      # your origin + /s3
+MINIO_ROOT_USER=nodum
+MINIO_ROOT_PASSWORD=…
+```
+
+**A managed store** — Hetzner Object Storage, AWS S3, Cloudflare R2, Backblaze.
+Setting `S3_ENDPOINT_URL` makes `compose.sh` drop MinIO, its volume and its
+memory budget from the stack, and hands durability to the provider:
+
+```ini
+S3_ENDPOINT_URL=https://fsn1.your-objectstorage.com
+S3_PUBLIC_URL=https://fsn1.your-objectstorage.com   # must EQUAL the endpoint
+S3_BUCKET_NAME=nodum
+S3_REGION=fsn1
+S3_ACCESS_KEY=…
+S3_SECRET_KEY=…
+```
+
+Three things worth knowing about the managed path:
+
+- `S3_PUBLIC_URL` **must equal** `S3_ENDPOINT_URL`. The presigned URL is already
+  public, so nothing rewrites it; a different value silently produces URLs that
+  404. The `/s3` Caddy route just goes unused.
+- `S3_REGION` is not cosmetic. SigV4 signs the region, so a wrong value fails
+  every request with `SignatureDoesNotMatch`. Hetzner uses the location code
+  (`fsn1`, `nbg1`, `hel1`), AWS `eu-central-1`, R2 `auto`.
+- **No bucket CORS needed.** Attachments only ever land in an `<img>`/`<iframe>`
+  `src`, never in a `fetch()`, so the browser never performs a preflight.
+
+Verify which mode you are in before deploying — `compose config --services`
+lists `minio` only for the bundled path.
 
 ## 3. Start
 


### PR DESCRIPTION
Needed for the `mtt` deployment, which uses Hetzner Object Storage.

The deploy layer **hardcoded** `S3_ENDPOINT_URL: http://minio:9000` and never passed `S3_REGION` or `S3_BUCKET_NAME` — so pointing a deployment at Hetzner, S3, R2 or Backblaze wasn't possible without editing compose.

Set `S3_ENDPOINT_URL` in the environment file and `compose.sh` layers in `docker-compose.external-s3.yml`, which takes MinIO out of the stack **and out of everything that waited on it**. One less stateful service, one less volume, one less thing in the backup plan, ~1 GB of memory budget back. Leave it unset and the bundled MinIO behaves exactly as before.

## Details that bite

- **`S3_PUBLIC_URL` must EQUAL `S3_ENDPOINT_URL`** for a managed store. The rewrite in `attachment_service` only fires when they differ, so a mismatched value silently yields presigned URLs that 404.
- **`S3_REGION` is now passed through.** SigV4 signs the region, so the previous hardcoded `us-east-1` would have failed every request against a provider that cares — as `SignatureDoesNotMatch`, which reads like a credentials problem.
- Credentials fall back to `MINIO_ROOT_USER`/`PASSWORD`, so the bundled path needs no duplication.
- **No bucket CORS needed** — attachments only ever land in an `<img>`/`<iframe>` `src`, never a `fetch()`, so there's no preflight.

`compose.sh` decides from the environment **file**, not the ambient environment: a stray exported variable in someone's shell must not change which services a deployment starts.

## Verified by booting both, not rendering them

| | Containers | MinIO volume | Attachment |
|---|---|---|---|
| **External** | 8, no `minio` | none created | confirmed in the external bucket via `list_objects_v2` |
| **Bundled** | 9, `/s3` route | as before | byte-identical round trip |

CI now renders the external path too and **fails if `minio` survives it**.

Backend 47 unit + 100 integration green, ruff clean, Caddyfile validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)