### PR TITLE
feat: implement password reset and account deletion flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ zip back whenever you want to leave.
   provider chain (Brevo → Mailjet → Resend → Mailgun → any SMTP relay), which both
   survives one provider's bad hour and stacks their free tiers. Outside production
   nothing is mailed and the code is always `123456`.
+- **Account recovery and closure** — forgotten-password reset by mailed code (which
+  drops every existing session, since that is what a reset is *for*), password change
+  from settings, and account deletion behind its own emailed code, taking the vaults,
+  notes and stored files with it. Codes are scoped by purpose, so a reset code cannot
+  delete an account.
 - **Built to scale** — async I/O end to end, Redis caching with targeted invalidation,
   Celery for import/export and background scans, WebGL rendering, CDN-friendly frontend.
 - **Operationally honest** — structured logging, request-id middleware, security headers,

--- a/back/alembic/versions/0017_otp_purposes.py
+++ b/back/alembic/versions/0017_otp_purposes.py
@@ -1,0 +1,37 @@
+"""email_verifications gains a purpose (signup / password reset / account delete)
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-08-19
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0017"
+down_revision: str | None = "0016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Existing rows are all signup codes, hence the default; it stays as a
+    # server_default so a code row can never be written without a purpose.
+    op.add_column(
+        "email_verifications",
+        sa.Column("purpose", sa.String(length=32), server_default="signup", nullable=False),
+    )
+    # Every lookup is "the pending code for this user and this purpose" — a
+    # password reset must not consume the signup code, or vice versa.
+    op.create_index(
+        "ix_email_verifications_user_purpose",
+        "email_verifications",
+        ["user_id", "purpose"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_email_verifications_user_purpose", table_name="email_verifications")
+    op.drop_column("email_verifications", "purpose")

--- a/back/app/api/v1/auth.py
+++ b/back/app/api/v1/auth.py
@@ -8,9 +8,12 @@ from app.dependencies.auth import CurrentUserId
 from app.dependencies.db import SessionDep
 from app.schemas.auth import (
     ChangePasswordRequest,
+    DeleteAccountRequest,
+    ForgotPasswordRequest,
     LoginRequest,
     RefreshRequest,
     ResendVerificationRequest,
+    ResetPasswordRequest,
     SignupRequest,
     TokenPairOut,
     UpdateProfileRequest,
@@ -18,7 +21,7 @@ from app.schemas.auth import (
     VerificationRequiredOut,
     VerifyEmailRequest,
 )
-from app.services import auth_service, email_verification_service
+from app.services import account_service, auth_service, email_verification_service
 from app.settings import get_settings
 from app.utils.cookie_utils import clear_refresh_cookie, read_refresh_cookie, set_refresh_cookie
 
@@ -120,6 +123,68 @@ async def resend_verification(body: ResendVerificationRequest, db: SessionDep) -
     (await email_verification_service.issue_code(db, user)).unwrap()
     await db.commit()
     return sent
+
+
+# ── Password reset ───────────────────────────────────────────────────────────
+
+
+@router.post("/forgot-password")
+async def forgot_password(body: ForgotPasswordRequest, db: SessionDep) -> dict[str, Any]:
+    """Mail a reset code.
+
+    Answers the same way for an address with no account: unauthenticated, so a
+    truthful answer would say which addresses are worth attacking.
+    """
+    (await account_service.request_password_reset(db, email=body.email)).unwrap()
+    return {"data": {"message": "If that address has an account, a reset code is on its way."}}
+
+
+@router.post("/reset-password")
+async def reset_password(
+    body: ResetPasswordRequest, request: Request, response: Response, db: SessionDep
+) -> dict[str, Any]:
+    """Set a new password from a mailed code and sign in with it.
+
+    Every session that existed before this call is already dead — see
+    account_service.reset_password.
+    """
+    user = (
+        await account_service.reset_password(db, email=body.email, code=body.code, new_password=body.new_password)
+    ).unwrap()
+    bundle = await auth_service.mint_session(
+        db,
+        user,
+        user_agent=request.headers.get("User-Agent"),
+        ip_address=request.client.host if request.client else None,
+    )
+    set_refresh_cookie(response, bundle.refresh_token)
+    return {"data": _token_payload(bundle).model_dump()}
+
+
+# ── Account deletion ─────────────────────────────────────────────────────────
+
+
+@router.post("/delete-account/request")
+async def request_account_deletion(user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Mail the code that authorises deleting this account."""
+    (await account_service.request_account_deletion(db, user_id)).unwrap()
+    settings = get_settings()
+    return {
+        "data": {
+            "message": "Check your email for the confirmation code.",
+            "expires_in_minutes": settings.EMAIL_OTP_TTL_MINUTES,
+        }
+    }
+
+
+@router.post("/delete-account")
+async def delete_account(
+    body: DeleteAccountRequest, user_id: CurrentUserId, response: Response, db: SessionDep
+) -> dict[str, Any]:
+    """Delete the account, its vaults, and the files behind them. Irreversible."""
+    (await account_service.delete_account(db, user_id, code=body.code)).unwrap()
+    clear_refresh_cookie(response)
+    return {"data": {"message": "Your account and everything in it has been deleted."}}
 
 
 @router.post("/refresh")

--- a/back/app/models/auth/verification.py
+++ b/back/app/models/auth/verification.py
@@ -28,6 +28,10 @@ class EmailVerification(UUIDMixin, TimestampMixin, Base):
         nullable=False,
         index=True,
     )
+    # What the code authorises: "signup", "password_reset" or "account_delete".
+    # Scoping every lookup by it is what stops one flow's code from being
+    # spent on another — a reset code must not delete an account.
+    purpose: Mapped[str] = mapped_column(String(32), nullable=False, default="signup", server_default="signup")
     code_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
@@ -37,4 +41,4 @@ class EmailVerification(UUIDMixin, TimestampMixin, Base):
     delivered_via: Mapped[str | None] = mapped_column(String(32), nullable=True, default=None)
 
     def __repr__(self) -> str:
-        return f"<EmailVerification user={self.user_id} expires={self.expires_at}>"
+        return f"<EmailVerification {self.purpose} user={self.user_id} expires={self.expires_at}>"

--- a/back/app/schemas/auth.py
+++ b/back/app/schemas/auth.py
@@ -42,6 +42,20 @@ class VerificationRequiredOut(BaseModel):
     expires_in_minutes: int
 
 
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    email: EmailStr
+    code: str = Field(min_length=4, max_length=12)
+    new_password: str = Field(min_length=8, max_length=128)
+
+
+class DeleteAccountRequest(BaseModel):
+    code: str = Field(min_length=4, max_length=12)
+
+
 class UserOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/back/app/services/account_service.py
+++ b/back/app/services/account_service.py
@@ -1,0 +1,158 @@
+"""Account recovery and closure — reset a forgotten password, delete an account.
+
+Both are gated on a one-time code mailed to the address on file, so both live
+here rather than in auth_service: what they have in common is proof of the
+mailbox, not of the password.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logging import get_logger
+from app.models.auth import User
+from app.models.vaults import Vault
+from app.services import email_verification_service as otp
+from app.services.service_response import ServiceResponse
+from app.utils.password_utils import hash_password_async
+
+logger = get_logger("account")
+
+
+async def request_password_reset(db: AsyncSession, *, email: str) -> ServiceResponse[None]:
+    """Mail a reset code, if there is anything to mail it to.
+
+    Always succeeds from the caller's point of view. This endpoint is
+    unauthenticated, so a truthful "no such account" would turn it into an
+    address oracle — and one that says which of a leaked list are real users.
+    """
+    user = await db.scalar(select(User).where(User.email == email.strip().lower()))
+    if user is None or not user.is_active:
+        logger.info("password_reset_requested_for_unknown_address")
+        return ServiceResponse.ok(None)
+
+    issued = await otp.issue_code(db, user, purpose=otp.PASSWORD_RESET)
+    if not issued.success:
+        # Swallowed on purpose. Reporting a cooldown here would undo the
+        # neutral answer above: ask twice in quick succession and only a real
+        # address would come back 429. The operator still sees it in the logs.
+        logger.info("password_reset_code_not_sent", user_id=str(user.id), reason=issued.error_code)
+        return ServiceResponse.ok(None)
+    await db.commit()
+    logger.info("password_reset_code_sent", user_id=str(user.id))
+    return ServiceResponse.ok(None)
+
+
+async def reset_password(db: AsyncSession, *, email: str, code: str, new_password: str) -> ServiceResponse[User]:
+    """Set a new password from a mailed code, and cut every existing session.
+
+    Sessions go because a reset is what someone does when they suspect they
+    have lost control of the account; leaving the intruder's refresh token
+    alive would defeat the whole exercise. The caller mints the new one.
+    """
+    from app.services.auth_service import revoke_existing_sessions
+
+    user = await db.scalar(select(User).where(User.email == email.strip().lower()))
+    if user is None or not user.is_active:
+        return ServiceResponse.fail("invalid_code", "That code is not valid. Request a new one.")
+
+    checked = await otp.check_code(db, user, code=code, purpose=otp.PASSWORD_RESET)
+    if not checked.success:
+        return ServiceResponse.fail(checked.error_code, checked.message)
+
+    user.password_hash = await hash_password_async(new_password)
+    # Reaching a code in the inbox proves the address as surely as signup does,
+    # so an account that never finished verifying is verified by this.
+    user.email_verified = True
+    await revoke_existing_sessions(db, user.id, "password_reset")
+    await db.commit()
+    logger.info("password_reset_completed", user_id=str(user.id))
+    return ServiceResponse.ok(user)
+
+
+async def request_account_deletion(db: AsyncSession, user_id: UUID) -> ServiceResponse[None]:
+    """Mail the code that authorises deleting this account."""
+    user = await db.get(User, user_id)
+    if user is None or not user.is_active:
+        return ServiceResponse.fail("unauthorized", "Account is not available.")
+
+    # Cooldown applies: this endpoint is reachable by anyone holding a session,
+    # and forcing would let one spam the owner's inbox (and the sending quota)
+    # at whatever the rate limiter allows. A repeat inside the window is told
+    # to wait, and the code already sent still works.
+    issued = await otp.issue_code(db, user, purpose=otp.ACCOUNT_DELETE)
+    if not issued.success:
+        return issued
+    await db.commit()
+    logger.info("account_deletion_code_sent", user_id=str(user.id))
+    return ServiceResponse.ok(None)
+
+
+async def delete_account(db: AsyncSession, user_id: UUID, *, code: str) -> ServiceResponse[None]:
+    """Delete the account, its vaults, and the files behind them.
+
+    Deliberately not gated on the password as well: accounts created through
+    Google sign-in carry a random one their owner has never seen, and locking
+    them out of closing their own account is worse than the marginal defence a
+    second factor buys here — the code already proves the mailbox.
+    """
+    user = await db.get(User, user_id)
+    if user is None:
+        return ServiceResponse.fail("unauthorized", "Account is not available.")
+
+    checked = await otp.check_code(db, user, code=code, purpose=otp.ACCOUNT_DELETE)
+    if not checked.success:
+        return ServiceResponse.fail(checked.error_code, checked.message)
+
+    vault_ids = list((await db.execute(select(Vault.id).where(Vault.user_id == user.id))).scalars())
+
+    # Object storage first, while the rows that name the vaults still exist. A
+    # DB cascade cannot reach into the bucket, and orphaned attachments are
+    # exactly the data someone closing an account expects to be gone.
+    for vault_id in vault_ids:
+        await _purge_vault_objects(vault_id)
+
+    from app.utils.cache_utils import cache_delete, vault_graph_key, vault_tree_key
+
+    for vault_id in vault_ids:
+        await cache_delete(vault_tree_key(vault_id), vault_graph_key(vault_id))
+
+    await db.delete(user)  # vaults, notes, sessions, bookmarks, AI rows all cascade
+    await db.commit()
+    logger.info("account_deleted", user_id=str(user_id), vaults=len(vault_ids))
+    return ServiceResponse.ok(None)
+
+
+async def _purge_vault_objects(vault_id: UUID) -> None:
+    """Delete everything under one vault's S3 prefix, in 1000-key batches.
+
+    Best-effort: a bucket that refuses must not strand the account in a
+    half-deleted state, so failures are logged and the DB delete proceeds.
+    """
+    import asyncio
+
+    from app.core.s3 import get_s3_client
+    from app.settings import get_settings
+
+    settings = get_settings()
+    prefix = f"vaults/{vault_id}/"
+
+    def purge() -> int:
+        client = get_s3_client()
+        removed = 0
+        paginator = client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=settings.S3_BUCKET_NAME, Prefix=prefix):
+            keys = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+            if not keys:
+                continue
+            client.delete_objects(Bucket=settings.S3_BUCKET_NAME, Delete={"Objects": keys})
+            removed += len(keys)
+        return removed
+
+    try:
+        removed = await asyncio.to_thread(purge)
+        if removed:
+            logger.info("vault_objects_purged", vault_id=str(vault_id), objects=removed)
+    except Exception as exc:  # closure must not hinge on the bucket
+        logger.warning("vault_objects_purge_failed", vault_id=str(vault_id), error=str(exc)[:200])

--- a/back/app/services/email_verification_service.py
+++ b/back/app/services/email_verification_service.py
@@ -1,4 +1,9 @@
-"""Email verification — issue a one-time code, check it, mark the address good.
+"""One-time email codes — issue, check, consume.
+
+Three flows share this: confirming a new signup, resetting a forgotten
+password, and deleting an account. They differ only in the copy of the email
+and in the ``purpose`` recorded on the row, and that purpose is what keeps them
+apart — a code mailed to reset a password must never delete an account.
 
 Production issues a random six-digit code and mails it through the provider
 chain. Every other environment issues the fixed ``EMAIL_OTP_DEV_CODE`` and
@@ -10,6 +15,7 @@ import hmac
 import secrets
 from datetime import UTC, datetime, timedelta
 from hashlib import sha256
+from typing import Literal
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,16 +28,25 @@ from app.settings import get_settings
 
 logger = get_logger("email_verification")
 
+Purpose = Literal["signup", "password_reset", "account_delete"]
+
+SIGNUP: Purpose = "signup"
+PASSWORD_RESET: Purpose = "password_reset"
+ACCOUNT_DELETE: Purpose = "account_delete"
+
 
 def verification_required() -> bool:
     return get_settings().EMAIL_VERIFICATION_REQUIRED
 
 
-def _hash_code(code: str) -> str:
+def _hash_code(code: str, purpose: Purpose) -> str:
     """HMAC, not a bare digest: six digits is a 10^6 space, so a plain SHA of
-    it is a lookup table. The app secret is what makes a dump useless."""
+    it is a lookup table. The app secret is what makes a dump useless.
+
+    The purpose is part of the message, so even identical codes issued for two
+    flows hash differently — belt and braces alongside the column filter."""
     settings = get_settings()
-    return hmac.new(settings.SECRET_KEY.encode(), code.encode(), sha256).hexdigest()
+    return hmac.new(settings.SECRET_KEY.encode(), f"{purpose}:{code}".encode(), sha256).hexdigest()
 
 
 def _new_code() -> str:
@@ -42,42 +57,66 @@ def _new_code() -> str:
     return settings.EMAIL_OTP_DEV_CODE
 
 
-def _email_body(name: str, code: str, ttl_minutes: int) -> tuple[str, str]:
+# ── Email copy, per purpose ──────────────────────────────────────────────────
+
+_COPY: dict[str, dict[str, str]] = {
+    SIGNUP: {
+        "subject": "Your Nodum verification code",
+        "lead": "Your Nodum verification code is",
+        "footer": "If you didn't create a Nodum account, ignore this email — nothing was set up.",
+    },
+    PASSWORD_RESET: {
+        "subject": "Reset your Nodum password",
+        "lead": "Use this code to set a new Nodum password:",
+        "footer": (
+            "If you didn't ask to reset your password, ignore this email — your "
+            "current password still works and nothing has changed."
+        ),
+    },
+    ACCOUNT_DELETE: {
+        "subject": "Confirm deleting your Nodum account",
+        "lead": "Use this code to delete your Nodum account and everything in it:",
+        "footer": (
+            "If you didn't ask to delete your account, ignore this email and change "
+            "your password — someone may be signed in as you."
+        ),
+    },
+}
+
+
+def _email_body(name: str, code: str, purpose: Purpose, ttl_minutes: int) -> tuple[str, str]:
+    copy = _COPY[purpose]
     greeting = f"Hi {name}," if name else "Hi,"
-    text = (
-        f"{greeting}\n\n"
-        f"Your Nodum verification code is {code}.\n\n"
-        f"It expires in {ttl_minutes} minutes. If you didn't create a Nodum "
-        f"account, you can ignore this email — nothing was set up.\n\n"
-        f"— Nodum\n"
-    )
+    text = f"{greeting}\n\n{copy['lead']} {code}\n\nIt expires in {ttl_minutes} minutes. {copy['footer']}\n\n— Nodum\n"
     html = f"""\
 <!doctype html>
 <html><body style="margin:0;padding:32px;background:#06060b;font-family:ui-sans-serif,system-ui,sans-serif;color:#ece9f5">
   <div style="max-width:480px;margin:0 auto">
     <p style="font-size:15px;line-height:1.6;color:#9c97b0;margin:0 0 24px">{greeting}</p>
-    <p style="font-size:15px;line-height:1.6;color:#9c97b0;margin:0 0 24px">
-      Your Nodum verification code is
-    </p>
+    <p style="font-size:15px;line-height:1.6;color:#9c97b0;margin:0 0 24px">{copy["lead"]}</p>
     <p style="font-family:ui-monospace,monospace;font-size:34px;letter-spacing:.32em;
               color:#ece9f5;margin:0 0 24px">{code}</p>
     <p style="font-size:14px;line-height:1.6;color:#8a86a0;margin:0 0 8px">
       It expires in {ttl_minutes} minutes.
     </p>
-    <p style="font-size:14px;line-height:1.6;color:#8a86a0;margin:0">
-      If you didn't create a Nodum account, ignore this email — nothing was set up.
-    </p>
+    <p style="font-size:14px;line-height:1.6;color:#8a86a0;margin:0">{copy["footer"]}</p>
   </div>
 </body></html>
 """
     return html, text
 
 
-async def issue_code(db: AsyncSession, user: User, *, force: bool = False) -> ServiceResponse[None]:
-    """Create (or replace) this user's pending code and send it.
+# ── Issue ────────────────────────────────────────────────────────────────────
 
-    ``force`` skips the resend cooldown; signup uses it, the resend endpoint
-    does not. The caller commits.
+
+async def issue_code(
+    db: AsyncSession, user: User, *, purpose: Purpose = SIGNUP, force: bool = False
+) -> ServiceResponse[None]:
+    """Create (or replace) this user's pending code for one purpose and send it.
+
+    ``force`` skips the resend cooldown; the flows that send a code as part of a
+    deliberate action (signing up, asking to delete) use it, the plain "send it
+    again" endpoints do not. The caller commits.
     """
     settings = get_settings()
     now = datetime.now(UTC)
@@ -85,7 +124,7 @@ async def issue_code(db: AsyncSession, user: User, *, force: bool = False) -> Se
     if not force:
         latest = await db.scalar(
             select(EmailVerification)
-            .where(EmailVerification.user_id == user.id)
+            .where(EmailVerification.user_id == user.id, EmailVerification.purpose == purpose)
             .order_by(EmailVerification.created_at.desc())
             .limit(1)
         )
@@ -95,57 +134,58 @@ async def issue_code(db: AsyncSession, user: User, *, force: bool = False) -> Se
                 wait = int(settings.EMAIL_OTP_RESEND_COOLDOWN_SECONDS - age)
                 return ServiceResponse.fail("rate_limited", f"A code was just sent. Try again in {wait} seconds.")
 
-    # One pending code per user: a replaced code must stop working immediately.
-    await db.execute(delete(EmailVerification).where(EmailVerification.user_id == user.id))
+    # One pending code per user per purpose: a replaced code must stop working
+    # immediately, but a reset code must not wipe a pending signup code.
+    await db.execute(
+        delete(EmailVerification).where(EmailVerification.user_id == user.id, EmailVerification.purpose == purpose)
+    )
 
     code = _new_code()
     record = EmailVerification(
         user_id=user.id,
-        code_hash=_hash_code(code),
+        purpose=purpose,
+        code_hash=_hash_code(code, purpose),
         expires_at=now + timedelta(minutes=settings.EMAIL_OTP_TTL_MINUTES),
     )
 
     if settings.ENVIRONMENT == "production":
-        html, text = _email_body(user.name, code, settings.EMAIL_OTP_TTL_MINUTES)
-        provider = await send_email(
-            to=user.email,
-            subject="Your Nodum verification code",
-            html=html,
-            text=text,
-        )
+        html, text = _email_body(user.name, code, purpose, settings.EMAIL_OTP_TTL_MINUTES)
+        provider = await send_email(to=user.email, subject=_COPY[purpose]["subject"], html=html, text=text)
         if provider is None:
             # Nothing to verify against: say so rather than stranding the user
             # on a code screen no email will ever satisfy.
             return ServiceResponse.fail(
                 "email_delivery_failed",
-                "We couldn't send your verification email. Please try again in a moment.",
+                "We couldn't send that email. Please try again in a moment.",
             )
         record.delivered_via = provider
     else:
         record.delivered_via = "dev"
-        logger.info("email_verification_dev_code", user_id=str(user.id), code=code)
+        logger.info("otp_dev_code", user_id=str(user.id), purpose=purpose, code=code)
 
     db.add(record)
     return ServiceResponse.ok(None)
 
 
-async def verify(db: AsyncSession, *, email: str, code: str) -> ServiceResponse[User]:
-    """Check a submitted code and mark the address verified. The caller commits."""
+# ── Check ────────────────────────────────────────────────────────────────────
+
+
+async def check_code(
+    db: AsyncSession, user: User, *, code: str, purpose: Purpose
+) -> ServiceResponse[EmailVerification]:
+    """Validate a submitted code and mark it consumed. The caller commits.
+
+    A wrong code is committed here on purpose: the attempt counter is the only
+    thing standing between a 10^6 space and a patient script.
+    """
     settings = get_settings()
-    email = email.strip().lower()
-    code = code.strip()
-
-    user = await db.scalar(select(User).where(User.email == email))
-    if user is None:
-        # Same shape as a wrong code — the endpoint is unauthenticated, so it
-        # must not say which addresses have accounts.
-        return ServiceResponse.fail("invalid_code", "That code is not valid. Request a new one.")
-    if user.email_verified:
-        return ServiceResponse.ok(user)
-
     record = await db.scalar(
         select(EmailVerification)
-        .where(EmailVerification.user_id == user.id, EmailVerification.consumed_at.is_(None))
+        .where(
+            EmailVerification.user_id == user.id,
+            EmailVerification.purpose == purpose,
+            EmailVerification.consumed_at.is_(None),
+        )
         .order_by(EmailVerification.created_at.desc())
         .limit(1)
         .with_for_update()
@@ -159,7 +199,7 @@ async def verify(db: AsyncSession, *, email: str, code: str) -> ServiceResponse[
     if record.attempts >= settings.EMAIL_OTP_MAX_ATTEMPTS:
         return ServiceResponse.fail("too_many_attempts", "Too many incorrect attempts. Request a new code.")
 
-    if not hmac.compare_digest(record.code_hash, _hash_code(code)):
+    if not hmac.compare_digest(record.code_hash, _hash_code(code.strip(), purpose)):
         record.attempts += 1
         await db.commit()
         remaining = max(0, settings.EMAIL_OTP_MAX_ATTEMPTS - record.attempts)
@@ -167,6 +207,24 @@ async def verify(db: AsyncSession, *, email: str, code: str) -> ServiceResponse[
         return ServiceResponse.fail("invalid_code", f"That code is not correct.{detail}")
 
     record.consumed_at = now
+    return ServiceResponse.ok(record)
+
+
+async def verify(db: AsyncSession, *, email: str, code: str) -> ServiceResponse[User]:
+    """Signup's flavour: check the code and mark the address verified."""
+    email = email.strip().lower()
+    user = await db.scalar(select(User).where(User.email == email))
+    if user is None:
+        # Same shape as a wrong code — the endpoint is unauthenticated, so it
+        # must not say which addresses have accounts.
+        return ServiceResponse.fail("invalid_code", "That code is not valid. Request a new one.")
+    if user.email_verified:
+        return ServiceResponse.ok(user)
+
+    checked = await check_code(db, user, code=code, purpose=SIGNUP)
+    if not checked.success:
+        return ServiceResponse.fail(checked.error_code, checked.message)
+
     user.email_verified = True
     logger.info("email_verified", user_id=str(user.id))
     return ServiceResponse.ok(user)

--- a/back/tests/integration/test_account_recovery.py
+++ b/back/tests/integration/test_account_recovery.py
@@ -1,0 +1,216 @@
+"""Password reset and account deletion — both gated on a mailed code.
+
+Needs the dev/test infra (postgres). Outside production the code is the fixed
+EMAIL_OTP_DEV_CODE and nothing is mailed.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.settings import get_settings
+
+
+def _creds() -> dict[str, str]:
+    return {
+        "email": f"recover-{uuid.uuid4().hex[:12]}@nodumtest.dev",
+        "password": "s3cure-Password!",
+        "name": "Recover User",
+    }
+
+
+async def _account(client: AsyncClient) -> tuple[dict[str, str], str]:
+    """A verified account and its access token."""
+    creds = _creds()
+    resp = await client.post("/api/v1/auth/signup", json=creds)
+    data = resp.json()["data"]
+    if "access_token" not in data:  # verification is on for this run
+        data = (
+            await client.post(
+                "/api/v1/auth/verify-email",
+                json={"email": creds["email"], "code": get_settings().EMAIL_OTP_DEV_CODE},
+            )
+        ).json()["data"]
+    client.cookies.clear()
+    return creds, data["access_token"]
+
+
+# ── Password reset ───────────────────────────────────────────────────────────
+
+
+async def test_reset_replaces_the_password_and_signs_in(client: AsyncClient) -> None:
+    creds, _ = await _account(client)
+    code = get_settings().EMAIL_OTP_DEV_CODE
+
+    assert (await client.post("/api/v1/auth/forgot-password", json={"email": creds["email"]})).status_code == 200
+
+    reset = await client.post(
+        "/api/v1/auth/reset-password",
+        json={"email": creds["email"], "code": code, "new_password": "a-Brand-New-Pass1"},
+    )
+    assert reset.status_code == 200, reset.text
+    assert reset.json()["data"]["access_token"]
+
+    client.cookies.clear()
+    old = await client.post("/api/v1/auth/login", json={"email": creds["email"], "password": creds["password"]})
+    assert old.status_code == 401, "the old password must stop working"
+
+    new = await client.post("/api/v1/auth/login", json={"email": creds["email"], "password": "a-Brand-New-Pass1"})
+    assert new.status_code == 200, new.text
+
+
+async def test_reset_kills_sessions_that_existed_before_it(client: AsyncClient) -> None:
+    """The point of a reset is losing control of the account — an intruder's
+    refresh token must not survive it."""
+    creds, token = await _account(client)
+    assert (await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})).status_code == 200
+
+    await client.post("/api/v1/auth/forgot-password", json={"email": creds["email"]})
+    await client.post(
+        "/api/v1/auth/reset-password",
+        json={
+            "email": creds["email"],
+            "code": get_settings().EMAIL_OTP_DEV_CODE,
+            "new_password": "a-Brand-New-Pass1",
+        },
+    )
+
+    stale = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert stale.status_code == 401
+
+
+async def test_forgot_password_says_nothing_about_who_has_an_account(client: AsyncClient) -> None:
+    known, _ = await _account(client)
+    a = await client.post("/api/v1/auth/forgot-password", json={"email": known["email"]})
+    b = await client.post("/api/v1/auth/forgot-password", json={"email": "ghost@nodumtest.dev"})
+    assert a.status_code == b.status_code == 200
+    assert a.json() == b.json()
+
+
+async def test_a_signup_code_cannot_reset_a_password(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Purpose scoping: the code sitting in the inbox from signing up is not a
+    reset code, even though both are six digits and both are live."""
+    # Verification on, so the signup really does mint a code — otherwise this
+    # would pass merely because no code exists at all.
+    monkeypatch.setattr(get_settings(), "EMAIL_VERIFICATION_REQUIRED", True)
+    creds = _creds()
+    signup = await client.post("/api/v1/auth/signup", json=creds)
+    assert signup.json()["data"]["status"] == "verification_required"
+
+    attempt = await client.post(
+        "/api/v1/auth/reset-password",
+        json={
+            "email": creds["email"],
+            "code": get_settings().EMAIL_OTP_DEV_CODE,
+            "new_password": "a-Brand-New-Pass1",
+        },
+    )
+    assert attempt.status_code == 422
+    assert attempt.json()["error"]["code"] == "invalid_code"
+
+
+# ── Account deletion ─────────────────────────────────────────────────────────
+
+
+async def test_deletion_needs_a_code_that_was_actually_requested(client: AsyncClient) -> None:
+    _, token = await _account(client)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    early = await client.post(
+        "/api/v1/auth/delete-account", json={"code": get_settings().EMAIL_OTP_DEV_CODE}, headers=auth
+    )
+    assert early.status_code == 422
+    assert early.json()["error"]["code"] == "invalid_code"
+
+
+async def test_deletion_removes_the_account_and_its_vaults(client: AsyncClient) -> None:
+    from app.core.db import async_session_factory
+    from app.models.auth import User
+    from app.models.vaults import Vault
+
+    creds, token = await _account(client)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    async with async_session_factory() as db:
+        user_id = await db.scalar(select(User.id).where(User.email == creds["email"]))
+        vaults_before = len(list((await db.execute(select(Vault.id).where(Vault.user_id == user_id))).scalars()))
+    assert vaults_before >= 1, "signup seeds a welcome vault"
+
+    assert (await client.post("/api/v1/auth/delete-account/request", headers=auth)).status_code == 200
+    gone = await client.post(
+        "/api/v1/auth/delete-account", json={"code": get_settings().EMAIL_OTP_DEV_CODE}, headers=auth
+    )
+    assert gone.status_code == 200, gone.text
+
+    async with async_session_factory() as db:
+        assert await db.scalar(select(User.id).where(User.email == creds["email"])) is None
+        assert list((await db.execute(select(Vault.id).where(Vault.user_id == user_id))).scalars()) == []
+
+    # The session it was deleted from is dead, and so is the login.
+    assert (await client.get("/api/v1/auth/me", headers=auth)).status_code == 401
+    client.cookies.clear()
+    assert (
+        await client.post("/api/v1/auth/login", json={"email": creds["email"], "password": creds["password"]})
+    ).status_code == 401
+
+
+async def test_deletion_needs_authentication(client: AsyncClient) -> None:
+    assert (await client.post("/api/v1/auth/delete-account/request")).status_code == 401
+    assert (await client.post("/api/v1/auth/delete-account", json={"code": "123456"})).status_code == 401
+
+
+@pytest.mark.parametrize("bad_code", ["000000", "111111"])
+async def test_a_wrong_deletion_code_leaves_the_account_alone(client: AsyncClient, bad_code: str) -> None:
+    _, token = await _account(client)
+    auth = {"Authorization": f"Bearer {token}"}
+    await client.post("/api/v1/auth/delete-account/request", headers=auth)
+
+    refused = await client.post("/api/v1/auth/delete-account", json={"code": bad_code}, headers=auth)
+    assert refused.status_code == 422
+    assert (await client.get("/api/v1/auth/me", headers=auth)).status_code == 200
+
+
+async def test_a_second_deletion_code_request_is_cooled_down(client: AsyncClient) -> None:
+    """Anyone holding a session can press this button; forcing a send every
+    time would let them spam the owner's inbox and the sending quota."""
+    _, token = await _account(client)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    assert (await client.post("/api/v1/auth/delete-account/request", headers=auth)).status_code == 200
+    again = await client.post("/api/v1/auth/delete-account/request", headers=auth)
+    assert again.status_code == 429
+    assert again.json()["error"]["code"] == "rate_limited"
+
+    # The code from the first request is still the live one.
+    gone = await client.post(
+        "/api/v1/auth/delete-account", json={"code": get_settings().EMAIL_OTP_DEV_CODE}, headers=auth
+    )
+    assert gone.status_code == 200, gone.text
+
+
+async def test_repeat_forgot_password_stays_neutral(client: AsyncClient) -> None:
+    """The cooldown must not become an oracle: asking twice in a row has to
+    look the same for a real address as for one with no account."""
+    creds, _ = await _account(client)
+
+    real_first = await client.post("/api/v1/auth/forgot-password", json={"email": creds["email"]})
+    real_second = await client.post("/api/v1/auth/forgot-password", json={"email": creds["email"]})
+    ghost_first = await client.post("/api/v1/auth/forgot-password", json={"email": "ghost@nodumtest.dev"})
+    ghost_second = await client.post("/api/v1/auth/forgot-password", json={"email": "ghost@nodumtest.dev"})
+
+    assert real_first.status_code == real_second.status_code == 200
+    assert ghost_first.status_code == ghost_second.status_code == 200
+    assert real_second.json() == ghost_second.json()
+
+    # And the code from the first request is still the live one.
+    reset = await client.post(
+        "/api/v1/auth/reset-password",
+        json={
+            "email": creds["email"],
+            "code": get_settings().EMAIL_OTP_DEV_CODE,
+            "new_password": "a-Brand-New-Pass1",
+        },
+    )
+    assert reset.status_code == 200, reset.text

--- a/deploy/smoke.sh
+++ b/deploy/smoke.sh
@@ -82,8 +82,12 @@ else
   elif [ "$(printf '%s' "$signup" | json_field status)" = "verification_required" ]; then
     # Not a failure: the account exists, the code row was written, and a
     # provider accepted the message — signup 502s when none of them do.
-    ok "signup through /api (verification required, code emailed)"
-    echo "      ↳ a real email went to $EMAIL; set SMOKE_EMAIL to stop bouncing mail at a dead domain"
+    ok "signup through /api (verification required, code issued)"
+    case "$SMOKE_ENV" in
+      prod|staging)
+        echo "      ↳ that mailed a real code to $EMAIL, a domain that does not exist."
+        echo "        Every run is another hard bounce — use SMOKE_EMAIL for anything but a one-off." ;;
+    esac
     if verify_in_db "$EMAIL"; then
       TOKEN=$(login "$EMAIL" "$PASSWORD")
       [ -n "$TOKEN" ] && ok "verified in the database, logged in" || bad "login after verifying failed"

--- a/docs/OWNER-SETUP.md
+++ b/docs/OWNER-SETUP.md
@@ -46,6 +46,10 @@ can do:
 
 ## 3. Email delivery (required in production — signup sends a code)
 
+Three flows mail a six-digit code: confirming a new signup, resetting a
+forgotten password, and deleting an account. They share one provider chain,
+so configuring it once covers all three.
+
 Production requires new accounts to confirm their address, so the API
 **refuses to boot** with `EMAIL_VERIFICATION_REQUIRED=true` and no provider
 configured. Outside production nothing is mailed and the code is always

--- a/tasks/nodum-master-plan.md
+++ b/tasks/nodum-master-plan.md
@@ -223,6 +223,30 @@ gitleaks clean → pushed to github.com/vorreix/nodum. Released as v1.0.0.
 
 ## 6. Progress Log
 
+- **2026-08-19 (account recovery and closure)** — Three flows now hang off the
+  signup OTP work: forgotten-password reset, password change from settings
+  (the endpoint and UI already existed — it needed coverage, not code), and
+  account deletion behind its own emailed code.
+  `email_verifications` gained a `purpose` column, and every lookup is scoped
+  by it, so the code sitting in an inbox from signing up cannot be spent on a
+  password reset — the purpose is mixed into the HMAC too, belt and braces.
+  Reset drops every session that existed before it: a reset is what someone
+  does when they suspect they have lost control of the account, so leaving the
+  intruder's refresh token alive would defeat the exercise. It also marks the
+  address verified, since reaching a mailed code proves the mailbox as surely
+  as signup does.
+  Deletion is *not* gated on the password as well as the code: accounts made
+  through Google sign-in carry a random password their owner has never seen
+  (oauth_service mints one), so requiring it would lock exactly those people
+  out of closing their own account. It purges each vault's S3 prefix before
+  the row goes, because a DB cascade cannot reach into the bucket and orphaned
+  attachments are precisely what someone closing an account expects to be
+  gone; the purge is best-effort so a sulking bucket cannot strand a
+  half-deleted account.
+  9 new backend tests + 3 new e2e; 171 backend and the full e2e suite green.
+  Note for later: the one-shot backend failure seen mid-run was Redis still
+  coming up with Docker, not a regression — two clean runs after.
+
 - **2026-08-19 (smoke.sh caught up with verification)** — The first production
   deploy reported `✗ signup failed: {"status":"verification_required"…}`. The
   deploy was healthy: that 201 proves the API answered, the user and code rows

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -113,3 +113,90 @@ test.describe("email verification", () => {
     await expect(page).toHaveURL(/\/vault\//, { timeout: 15_000 });
   });
 });
+
+/** Forgotten password: code + new password in one step, old sessions dropped. */
+test.describe("password reset", () => {
+  test("a reset code sets a new password and signs in", async ({ page }) => {
+    const email = await signupFreshUser(page, "reset-e2e");
+    await page.getByRole("button", { name: "Log out" }).click();
+    await expect(page).toHaveURL(/\/$/, { timeout: 10_000 });
+
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(email);
+    await page.getByRole("button", { name: "Forgot password?" }).click();
+
+    await expect(page.getByRole("heading", { name: "Set a new password" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByLabel("Reset code").fill("000000");
+    await page.getByLabel("New password").fill("a-Brand-New-Pass1");
+    await page.getByRole("button", { name: "Set password and sign in" }).click();
+    await expect(page.getByText(/not correct/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.getByLabel("Reset code").fill(DEV_OTP);
+    await page.getByLabel("New password").fill("a-Brand-New-Pass1");
+    await page.getByRole("button", { name: "Set password and sign in" }).click();
+    await expect(page).toHaveURL(/\/vault\//, { timeout: 15_000 });
+
+    // The new password is the one that works now.
+    await page.getByRole("button", { name: "Log out" }).click();
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(PASSWORD);
+    await page.getByRole("button", { name: "Log in" }).click();
+    await expect(page.getByText(/invalid email or password/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.getByLabel("Password").fill("a-Brand-New-Pass1");
+    await page.getByRole("button", { name: "Log in" }).click();
+    await expect(page).toHaveURL(/\/vault\//, { timeout: 15_000 });
+  });
+});
+
+/** Account settings: changing the password, and closing the account for good. */
+test.describe("account settings", () => {
+  test("the password can be changed from settings", async ({ page }) => {
+    const email = await signupFreshUser(page, "changepw-e2e");
+
+    await page.keyboard.press("ControlOrMeta+Comma");
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByRole("heading", { name: "Settings" })).toBeVisible({ timeout: 10_000 });
+    await dialog.getByLabel("Current").fill(PASSWORD);
+    await dialog.getByLabel("New (min 8)").fill("changed-Password-9");
+    await dialog.getByRole("button", { name: "Change password" }).click();
+    await expect(page.getByText(/password changed/i)).toBeVisible({ timeout: 10_000 });
+
+    // Changing it logs every session out, so the app returns to the login page.
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill("changed-Password-9");
+    await page.getByRole("button", { name: "Log in" }).click();
+    await expect(page).toHaveURL(/\/vault\//, { timeout: 15_000 });
+  });
+
+  test("deleting the account needs the emailed code, then takes everything", async ({ page }) => {
+    const email = await signupFreshUser(page, "delete-e2e");
+
+    await page.keyboard.press("ControlOrMeta+Comma");
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByRole("heading", { name: "Settings" })).toBeVisible({ timeout: 10_000 });
+
+    await dialog.getByRole("button", { name: "Delete account" }).click();
+    await dialog.getByRole("button", { name: "Email me a code" }).click();
+    await expect(dialog.getByLabel("Confirmation code")).toBeVisible({ timeout: 10_000 });
+
+    await dialog.getByLabel("Confirmation code").fill("000000");
+    await dialog.getByRole("button", { name: "Delete my account permanently" }).click();
+    await expect(page.getByText(/not correct/i)).toBeVisible({ timeout: 10_000 });
+
+    await dialog.getByLabel("Confirmation code").fill(DEV_OTP);
+    await dialog.getByRole("button", { name: "Delete my account permanently" }).click();
+
+    // Back to the landing page, and the account no longer exists.
+    await expect(page).toHaveURL(/\/$/, { timeout: 15_000 });
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(PASSWORD);
+    await page.getByRole("button", { name: "Log in" }).click();
+    await expect(page.getByText(/invalid email or password/i)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/web/src/components/auth/auth-form.tsx
+++ b/web/src/components/auth/auth-form.tsx
@@ -12,6 +12,7 @@ import { authApi } from "@/lib/api/endpoints";
 import { isVerificationRequired } from "@/lib/api/types";
 import { useAuthStore } from "@/lib/stores/auth-store";
 
+import { ResetStep } from "./reset-step";
 import { VerifyStep } from "./verify-step";
 
 export function AuthForm({ mode }: { mode: "login" | "signup" }) {
@@ -29,6 +30,8 @@ export function AuthForm({ mode }: { mode: "login" | "signup" }) {
     ttlMinutes: number;
     justSent: boolean;
   } | null>(null);
+  // Set once a reset code has been requested for this address.
+  const [resetting, setResetting] = useState<{ email: string; ttlMinutes: number } | null>(null);
   const { data: providers } = useQuery({
     queryKey: ["auth-providers"],
     queryFn: authApi.providers,
@@ -66,6 +69,42 @@ export function AuthForm({ mode }: { mode: "login" | "signup" }) {
       setPending(false);
     }
   };
+
+  /** "Forgot password?" — send the code, then show the reset screen. The
+   *  server answers the same way for an address with no account, so this can
+   *  proceed without confirming anything about it. */
+  const startReset = async () => {
+    // Checked here because the button is outside the form's own validation,
+    // and the server's answer to a malformed address is a bare 422.
+    if (!/.+@.+\..+/.test(email.trim())) {
+      setError("Enter your email address first, then we can send you a reset code.");
+      return;
+    }
+    setError(null);
+    setPending(true);
+    try {
+      await authApi.forgotPassword({ email });
+      setResetting({ email, ttlMinutes: 15 });
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Could not send a reset code.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  if (resetting) {
+    return (
+      <ResetStep
+        email={resetting.email}
+        ttlMinutes={resetting.ttlMinutes}
+        onReset={(pair) => {
+          applyTokens(pair);
+          router.replace("/vault");
+        }}
+        onBack={() => setResetting(null)}
+      />
+    );
+  }
 
   if (awaitingCode) {
     return (
@@ -156,8 +195,16 @@ export function AuthForm({ mode }: { mode: "login" | "signup" }) {
               {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
             </button>
           </div>
-          {mode === "signup" && (
+          {mode === "signup" ? (
             <p className="mt-2 text-[0.75rem] text-[var(--mk-faint)]">At least 8 characters.</p>
+          ) : (
+            <button
+              type="button"
+              onClick={startReset}
+              className="mt-2 text-[0.75rem] text-[var(--mk-faint)] underline-offset-4 hover:text-[var(--mk-violet)] hover:underline"
+            >
+              Forgot password?
+            </button>
           )}
         </div>
 

--- a/web/src/components/auth/reset-step.tsx
+++ b/web/src/components/auth/reset-step.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+
+import { Eye, EyeOff } from "lucide-react";
+
+import { ApiError } from "@/lib/api/client";
+import { authApi } from "@/lib/api/endpoints";
+import type { TokenPair } from "@/lib/api/types";
+
+const RESEND_COOLDOWN_SECONDS = 60;
+
+/** Forgotten-password screen: the mailed code and the new password together,
+ *  so proving the mailbox and choosing the password are one step. */
+export function ResetStep({
+  email,
+  ttlMinutes,
+  onReset,
+  onBack,
+}: {
+  email: string;
+  ttlMinutes: number;
+  onReset: (pair: TokenPair) => void;
+  onBack: () => void;
+}) {
+  const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [cooldown, setCooldown] = useState(RESEND_COOLDOWN_SECONDS);
+  const codeRef = useRef<HTMLInputElement>(null);
+  const errorId = useId();
+
+  useEffect(() => {
+    codeRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const timer = setInterval(() => setCooldown((s) => (s <= 1 ? 0 : s - 1)), 1000);
+    return () => clearInterval(timer);
+  }, [cooldown]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setNotice(null);
+    setPending(true);
+    try {
+      onReset(await authApi.resetPassword({ email, code, new_password: password }));
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Something went wrong. Please try again.");
+      setPending(false);
+      setCode("");
+      codeRef.current?.focus();
+    }
+  };
+
+  const resend = async () => {
+    setError(null);
+    setNotice(null);
+    try {
+      await authApi.forgotPassword({ email });
+      setNotice("A new code is on its way.");
+      setCooldown(RESEND_COOLDOWN_SECONDS);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "Could not send a new code.");
+    }
+  };
+
+  return (
+    <div className="mk-in">
+      <h1 className="mk-display text-[2rem] tracking-[-0.03em]">Set a new password</h1>
+      <p className="mt-2 text-[0.9375rem] leading-relaxed text-[var(--mk-muted)]">
+        If <span className="text-[var(--mk-paper)]">{email}</span> has an account, a six-digit code
+        is on its way. It expires in {ttlMinutes} minutes.
+      </p>
+
+      <form onSubmit={submit} className="mt-8 space-y-4">
+        <div>
+          <label className="mk-label" htmlFor="reset-code">
+            Reset code
+          </label>
+          <input
+            id="reset-code"
+            ref={codeRef}
+            className="mk-field mk-mono text-center text-[1.25rem] tracking-[0.55em]"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={6}
+            placeholder="000000"
+            aria-describedby={error ? errorId : undefined}
+          />
+        </div>
+
+        <div>
+          <label className="mk-label" htmlFor="reset-password">
+            New password
+          </label>
+          <div className="relative">
+            <input
+              id="reset-password"
+              className="mk-field pr-11"
+              type={showPassword ? "text" : "password"}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              minLength={8}
+              autoComplete="new-password"
+            />
+            <button
+              type="button"
+              className="mk-field-button"
+              onClick={() => setShowPassword((v) => !v)}
+              aria-label={showPassword ? "Hide characters" : "Show characters"}
+            >
+              {showPassword ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+            </button>
+          </div>
+          <p className="mt-2 text-[0.75rem] text-[var(--mk-faint)]">
+            At least 8 characters. Everywhere you are signed in will be signed out.
+          </p>
+        </div>
+
+        {error && (
+          <p id={errorId} role="alert" className="text-[0.875rem] text-[#ff6b81]">
+            {error}
+          </p>
+        )}
+        {notice && <p className="text-[0.875rem] text-[var(--mk-violet)]">{notice}</p>}
+
+        <button
+          type="submit"
+          className="mk-btn mk-btn--primary w-full"
+          disabled={pending || code.length < 6 || password.length < 8}
+        >
+          {pending ? "Setting it…" : "Set password and sign in"}
+        </button>
+      </form>
+
+      <div className="mt-8 flex items-center justify-between text-[0.875rem] text-[var(--mk-muted)]">
+        <button
+          type="button"
+          onClick={resend}
+          disabled={cooldown > 0}
+          className="text-[var(--mk-violet)] underline-offset-4 hover:underline disabled:text-[var(--mk-faint)] disabled:no-underline"
+        >
+          {cooldown > 0 ? `Resend code in ${cooldown}s` : "Send a new code"}
+        </button>
+        <button type="button" onClick={onBack} className="underline-offset-4 hover:underline">
+          Back to log in
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/workspace/delete-account.tsx
+++ b/web/src/components/workspace/delete-account.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * Closing the account. Two deliberate steps — ask for a code, then type it —
+ * because everything this removes (vaults, notes, attachments) is gone for
+ * good, and the code proves the person pressing the button still owns the
+ * mailbox rather than just a borrowed session.
+ */
+
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { ApiError } from "@/lib/api/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { authApi } from "@/lib/api/endpoints";
+import { useAuthStore } from "@/lib/stores/auth-store";
+import { toastError, useToastStore } from "@/lib/stores/toast-store";
+
+export function DeleteAccountSection({ email }: { email: string | undefined }) {
+  const [stage, setStage] = useState<"idle" | "confirming" | "code">("idle");
+  const [code, setCode] = useState("");
+  const clearSession = useAuthStore((s) => s.logout);
+  const router = useRouter();
+
+  const requestCode = useMutation({
+    mutationFn: authApi.requestAccountDeletion,
+    onSuccess: () => {
+      setStage("code");
+      useToastStore.getState().push(`Confirmation code sent to ${email ?? "your email"}.`, "info");
+    },
+    onError: (e) => {
+      // "One was just sent" is not a dead end — that code is in their inbox
+      // and still works, so go to the code screen and say so.
+      if (e instanceof ApiError && e.code === "rate_limited") {
+        setStage("code");
+        useToastStore.getState().push(e.message, "info");
+        return;
+      }
+      toastError(e, "Could not send the confirmation code.");
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: () => authApi.deleteAccount({ code }),
+    onSuccess: async () => {
+      // The account is gone server-side; drop the session first so the
+      // workspace does not 401 its way through a re-render on the way out.
+      await clearSession().catch(() => {});
+      router.replace("/");
+    },
+    onError: (e) => toastError(e, "Could not delete the account."),
+  });
+
+  return (
+    <section className="space-y-3 border-t border-ob-border pt-4">
+      <h3 className="text-[11px] font-medium tracking-wide text-ob-faint uppercase">Danger zone</h3>
+
+      {stage === "idle" && (
+        <>
+          <p className="text-[12px] text-ob-faint">
+            Deleting your account removes every vault, note and attachment you have. It cannot be
+            undone.
+          </p>
+          <Button size="sm" variant="destructive" onClick={() => setStage("confirming")}>
+            Delete account
+          </Button>
+        </>
+      )}
+
+      {stage === "confirming" && (
+        <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+          <p className="text-[12px] text-ob-text">
+            This deletes your vaults, every note in them, and every file you have uploaded — for
+            good. We&apos;ll email a confirmation code to {email} first.
+          </p>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => requestCode.mutate()}
+              disabled={requestCode.isPending}
+            >
+              {requestCode.isPending ? "Sending…" : "Email me a code"}
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => setStage("idle")}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {stage === "code" && (
+        <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+          {/* The warning belongs on the screen where the irreversible button
+              actually is, not only on the one before it. */}
+          <p className="text-[12px] text-ob-text">
+            Enter the code we sent to {email}. This deletes every vault, note and file you have,
+            and cannot be undone.
+          </p>
+          <div className="space-y-2">
+            <Label htmlFor="delete-code">Confirmation code</Label>
+            <Input
+              id="delete-code"
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              maxLength={6}
+              placeholder="000000"
+              className="font-mono tracking-[0.4em]"
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => remove.mutate()}
+              disabled={remove.isPending || code.length < 6}
+            >
+              {remove.isPending ? "Deleting…" : "Delete my account permanently"}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setCode("");
+                setStage("idle");
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/workspace/settings-modal.tsx
+++ b/web/src/components/workspace/settings-modal.tsx
@@ -10,6 +10,7 @@ import { useRef, useState } from "react";
 
 import { AiSettingsTab } from "./ai-settings-tab";
 import { ClipperTab } from "./clipper-tab";
+import { DeleteAccountSection } from "./delete-account";
 import { PluginsTab } from "./plugins-tab";
 import { VaultsSection } from "./vaults-section";
 import { Button } from "@/components/ui/button";
@@ -367,6 +368,8 @@ export function SettingsModal({ vaultId, open, onOpenChange }: SettingsModalProp
                     Change password
                   </Button>
                 </section>
+
+                <DeleteAccountSection email={user?.email} />
               </>
             )}
 

--- a/web/src/lib/api/endpoints.ts
+++ b/web/src/lib/api/endpoints.ts
@@ -41,6 +41,14 @@ export const authApi = {
     apiJson<TokenPair>("/auth/verify-email", "POST", body),
   resendVerification: (body: { email: string }) =>
     apiJson<{ message: string }>("/auth/resend-verification", "POST", body),
+  forgotPassword: (body: { email: string }) =>
+    apiJson<{ message: string }>("/auth/forgot-password", "POST", body),
+  resetPassword: (body: { email: string; code: string; new_password: string }) =>
+    apiJson<TokenPair>("/auth/reset-password", "POST", body),
+  requestAccountDeletion: () =>
+    apiJson<{ message: string; expires_in_minutes: number }>("/auth/delete-account/request", "POST"),
+  deleteAccount: (body: { code: string }) =>
+    apiJson<{ message: string }>("/auth/delete-account", "POST", body),
   refresh: () => apiJson<TokenPair>("/auth/refresh", "POST"),
   logout: () => apiJson<{ message: string }>("/auth/logout", "POST"),
   me: () => api<User>("/auth/me"),


### PR DESCRIPTION
- Added functionality for users to reset their password using a one-time code sent to their email.
- Introduced a new endpoint for requesting a password reset and another for resetting the password.
- Implemented account deletion process requiring a confirmation code sent to the user's email.
- Updated the database schema to include a purpose for email verifications (signup, password reset, account deletion).
- Enhanced the frontend with new components for password reset and account deletion, including UI for entering codes and managing states.
- Added integration tests to ensure the correctness of the new features and their interactions.