### PR TITLE
docs: Developers section — API guides and recipes

### DIFF
--- a/web/e2e/api-keys.spec.ts
+++ b/web/e2e/api-keys.spec.ts
@@ -94,6 +94,16 @@ test.describe("API keys", () => {
     await expect(page.getByRole("heading", { level: 1 })).toContainText("API");
     await expect(page.locator(".mk-docs-figure img")).toHaveCount(2);
 
+    // The Developers section: guides render with their endpoint walkthroughs.
+    for (const [slug, marker] of [
+      ["api-notes", "Edit safely"],
+      ["api-search-links", "Unlink"],
+      ["api-recipes", "Capture from anywhere"],
+    ] as const) {
+      await page.goto(`/docs/${slug}`);
+      await expect(page.getByRole("heading", { name: new RegExp(marker) })).toBeVisible();
+    }
+
     await page.goto("/api-reference");
     await expect(page.getByRole("heading", { name: "Nodum API" })).toBeVisible({ timeout: 20_000 });
     // A real operation from the spec, rendered by Scalar — and the try-it

--- a/web/src/content/docs/api-notes.md
+++ b/web/src/content/docs/api-notes.md
@@ -1,0 +1,121 @@
+---
+title: "API guide: notes and files"
+section: Developers
+order: 2
+summary: Every notes and attachments endpoint with a copy-paste request and a real response — create, read, edit safely, move, tag, upload, delete.
+where: Base URL and keys live in Settings → API keys
+---
+
+Everything below assumes two shell variables:
+
+```bash
+NODUM=https://your-nodum/api/public/v1
+KEY="nodum_key_…"        # Settings → API keys
+```
+
+and sends the key the same way every time: `-H "Authorization: Bearer $KEY"`.
+Success is always `{"data": ...}`; errors are always
+`{"error": {"code", "message"}}`. **Writes return metadata, never bodies** —
+reading content back needs the `read` scope.
+
+## Find your vault
+
+```bash
+curl -H "Authorization: Bearer $KEY" $NODUM/vaults
+```
+
+```json
+{ "data": [ { "id": "0198…", "name": "Second Brain",
+              "created_at": "2026-08-01T09:00:00Z", "updated_at": "2026-08-21T07:00:00Z" } ] }
+```
+
+Every other call takes that `id` in the path. `GET /vaults/{id}/tree` returns
+the folder/note tree (titles only, no bodies) if you want the whole shape at
+once.
+
+## Create a note — `POST /vaults/{id}/notes` *(write)*
+
+```bash
+curl -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"title": "Standup 21 Aug", "folder": "Work/Standups", "content": "- Shipped [[Public API]]\n"}' \
+  $NODUM/vaults/$VAULT/notes
+```
+
+```json
+{ "data": { "id": "0198…", "folder_id": "0198…", "title": "Standup 21 Aug",
+            "path": "Work/Standups/Standup 21 Aug",
+            "created_at": "…", "updated_at": "…" } }
+```
+
+Missing folders in `folder` are created. A duplicate path is `409
+already_exists`. `[[Wikilinks]]` in the content resolve immediately.
+
+## Read — `GET /vaults/{id}/notes/{note_id}` or `/notes/by-path?path=…` *(read)*
+
+The full note: `content`, `properties` (parsed frontmatter), `word_count`,
+plus the metadata above. `by-path` takes the exact path
+(`Work/Standups/Standup 21 Aug`).
+
+## List — `GET /vaults/{id}/notes` *(read)*
+
+`?folder=Work&limit=50&offset=0` — metadata only, most recently updated
+first, `total` for pagination:
+
+```json
+{ "data": { "items": [ … ], "total": 128, "limit": 50, "offset": 0 } }
+```
+
+## Edit safely — `PUT /vaults/{id}/notes/{note_id}/content` *(write)*
+
+Three modes:
+
+- `{"content": "...", "mode": "replace"}` — the whole body. Send
+  `base_updated_at` (the `updated_at` you last read) and a stale write
+  returns `409 conflict` with `details.server_updated_at` so you can merge
+  instead of overwrite.
+- `{"content": "New line", "mode": "append"}` — added to the end. Composed
+  on the server against the current body, so two clients appending at the
+  same moment both land.
+- `"mode": "prepend"` — added at the top, always *below* the frontmatter.
+
+## Rename or move — `PATCH /vaults/{id}/notes/{note_id}` *(write)*
+
+```bash
+curl -X PATCH -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"title": "Standup 2026-08-21", "folder": "Archive/Standups"}' \
+  $NODUM/vaults/$VAULT/notes/$NOTE
+```
+
+`"folder": ""` moves to the vault root. Links pointing at the note keep
+working — Nodum re-resolves them.
+
+## Tags — `POST /vaults/{id}/notes/{note_id}/tags` *(write)*
+
+`{"add": ["work/standup"], "remove": []}` — edits the frontmatter `tags`
+list; inline `#tags` in the body are never touched.
+
+## Delete — `DELETE /vaults/{id}/notes/{note_id}` *(delete)*
+
+Links pointing at the deleted note become unresolved ghosts in the graph.
+
+## Files — `/vaults/{id}/attachments`
+
+- `POST` *(write)* — multipart, field `file`:
+  `curl -F "file=@diagram.png" …/attachments`. 5 MB cap, type checked by
+  content. Embed it in a note with `![[diagram.png]]`.
+- `GET` *(read)* — list: `{id, filename, mime_type, size_bytes, created_at}`.
+- `GET …/{attachment_id}/url` *(read)* — `{"url": …, "expires_in": 300}`, a
+  time-limited download URL.
+- `DELETE …/{attachment_id}` *(delete)*.
+
+## The errors you will actually see
+
+| Code | Meaning |
+| --- | --- |
+| `unauthorized` (401) | Missing, mistyped or revoked key — or a password change revoked it. |
+| `forbidden` (403) | The key lacks the scope; the message names which one. |
+| `not_found` (404) | Not there — or not yours. Deliberately the same answer. |
+| `already_exists` (409) | A note at that path already exists. |
+| `conflict` (409) | Stale `base_updated_at`; `details.server_updated_at` says what won. |
+| `validation_failed` (422) | Bad input; the message says what. |
+| `rate_limited` (429) | Slow down — 300 requests/minute per key by default. |

--- a/web/src/content/docs/api-recipes.md
+++ b/web/src/content/docs/api-recipes.md
@@ -1,0 +1,117 @@
+---
+title: "API recipes"
+section: Developers
+order: 4
+summary: Small working programs on top of the API — a shell capture alias, a Python daily-digest bot, a JavaScript backlink janitor — ready to paste and adapt.
+where: Each recipe says which scopes its key needs
+---
+
+Three complete programs, smallest first. Each one runs as-is once you fill
+in the two constants at the top. Mint a key with **only the scopes the
+recipe names** — least privilege is one checkbox away.
+
+## 1. Capture from anywhere (shell · scopes: `read`, `write`)
+
+An `inbox` command that appends a thought to today's inbox note — creating
+it the first time — from any terminal:
+
+```bash
+# ~/.zshrc
+NODUM=https://your-nodum/api/public/v1
+NODUM_KEY="nodum_key_…"          # read + write
+NODUM_VAULT="<vault id>"
+
+inbox() {
+  local day=$(date +%Y-%m-%d) body="- $*"
+  local id=$(curl -s -H "Authorization: Bearer $NODUM_KEY" \
+      "$NODUM/vaults/$NODUM_VAULT/notes/by-path?path=Inbox/$day" | python3 -c \
+      'import json,sys;d=json.load(sys.stdin);print(d.get("data",{}).get("id",""))')
+  if [ -z "$id" ]; then
+    curl -s -H "Authorization: Bearer $NODUM_KEY" -H "Content-Type: application/json" \
+      -d "{\"title\": \"$day\", \"folder\": \"Inbox\", \"content\": \"$body\"}" \
+      "$NODUM/vaults/$NODUM_VAULT/notes" >/dev/null
+  else
+    curl -s -X PUT -H "Authorization: Bearer $NODUM_KEY" -H "Content-Type: application/json" \
+      -d "{\"content\": \"$body\", \"mode\": \"append\"}" \
+      "$NODUM/vaults/$NODUM_VAULT/notes/$id/content" >/dev/null
+  fi
+}
+```
+
+`inbox call the plumber` → one more line in today's inbox, from any shell.
+
+## 2. A morning digest, written by your vault (Python · scopes: `read`, `ai`, `write`)
+
+Asks the vault's AI for a summary of yesterday's edits and files it as a
+note — run it from cron:
+
+```python
+#!/usr/bin/env python3
+import datetime, json, urllib.request
+
+NODUM = "https://your-nodum/api/public/v1"
+KEY   = "nodum_key_…"          # read + ai + write
+VAULT = "<vault id>"
+
+def call(method, path, body=None):
+    req = urllib.request.Request(
+        f"{NODUM}{path}", method=method,
+        headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"},
+        data=json.dumps(body).encode() if body else None)
+    with urllib.request.urlopen(req, timeout=180) as r:   # ai/ask can be slow
+        return json.load(r)["data"]
+
+yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+recent = call("GET", f"/vaults/{VAULT}/notes?limit=20")
+edited = [n["title"] for n in recent["items"] if n["updated_at"][:10] == yesterday]
+
+answer = call("POST", f"/vaults/{VAULT}/ai/ask", {
+    "message": "Write a five-line digest of what changed in these notes yesterday: "
+               + ", ".join(edited) if edited else "Say the vault was quiet yesterday."})
+
+call("POST", f"/vaults/{VAULT}/notes", {
+    "title": f"Digest {yesterday}", "folder": "Digests",
+    "content": answer["reply"]})
+print("filed", f"Digests/Digest {yesterday}")
+```
+
+## 3. A backlink janitor (Node.js · scopes: `read`, `write`)
+
+Finds notes that *mention* a hub note without linking it, and links them:
+
+```js
+#!/usr/bin/env node
+const NODUM = "https://your-nodum/api/public/v1";
+const KEY = "nodum_key_…"; // read + write
+const VAULT = "<vault id>";
+const HUB = "Projects/Alpha"; // the note that should be linked from everywhere
+
+const api = async (method, path, body) => {
+  const r = await fetch(`${NODUM}${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${KEY}`, "Content-Type": "application/json" },
+    body: body && JSON.stringify(body),
+  });
+  const j = await r.json();
+  if (!r.ok) throw new Error(j.error.message);
+  return j.data;
+};
+
+const hub = await api("GET", `/vaults/${VAULT}/notes/by-path?path=${encodeURIComponent(HUB)}`);
+const { unlinked_mentions } = await api("GET", `/vaults/${VAULT}/notes/${hub.id}/unlinked-mentions`);
+for (const m of unlinked_mentions ?? []) {
+  const res = await api("POST", `/vaults/${VAULT}/notes/${m.note_id}/links`, { target: hub.id });
+  console.log(res.already_linked ? "already" : "linked", m.path);
+}
+```
+
+## Habits that keep these robust
+
+- **One key per program**, named after it, with only the scopes it needs —
+  revoking one never breaks the others.
+- **Treat 409 as information**: `already_exists` means create-once logic can
+  be a plain retry; `conflict` means re-read, merge, re-send.
+- **Remember the password rule**: changing or resetting the account password
+  revokes every key. Cron jobs fail with `401` — mint fresh keys after.
+- The [interactive reference](/api-reference) shows every endpoint with
+  generated snippets in more languages — paste a key and try calls live.

--- a/web/src/content/docs/api-search-links.md
+++ b/web/src/content/docs/api-search-links.md
@@ -1,0 +1,101 @@
+---
+title: "API guide: search, links & graph"
+section: Developers
+order: 3
+summary: Full-text search with operators, fuzzy title matching, linking and unlinking notes, backlinks, tags and the knowledge graph — each with a working request.
+where: Base URL and keys live in Settings → API keys
+---
+
+Same setup as the [notes guide](/docs/api-notes): `$NODUM` is the base URL,
+`$KEY` the API key, and every endpoint here needs only the `read` scope
+unless marked *(write)*.
+
+## Search — `GET /vaults/{id}/search`
+
+```bash
+curl -H "Authorization: Bearer $KEY" \
+  "$NODUM/vaults/$VAULT/search?q=spaced%20repetition&limit=20"
+```
+
+```json
+{ "data": { "query": "spaced repetition", "total": 7,
+  "results": [ { "id": "0198…", "title": "Learning", "path": "Topics/Learning",
+                 "snippet": "…the case for <mark>spaced</mark> <mark>repetition</mark>…",
+                 "rank": 0.61, "created_at": "…", "updated_at": "…" } ] } }
+```
+
+The query language is the app's: `path:Folder` and `file:Name` narrow,
+`tag:#name` filters by tag, `-word` excludes, `"a phrase"` matches exactly.
+`sort` is `relevance` (default), `updated`, `created` or `title`;
+`limit`/`offset` paginate with an honest `total`.
+
+## Fuzzy titles — `GET /vaults/{id}/quick-switch?q=lear`
+
+What ⌘O uses: cheap fuzzy matching over titles and frontmatter aliases —
+`[{id, title, path, score, alias?}]`. Empty `q` returns the most recent
+notes. Use it to resolve half-remembered names before a precise call.
+
+## Link two notes — `POST /vaults/{id}/notes/{note_id}/links` *(write)*
+
+```bash
+curl -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"target": "Topics/Learning"}' \
+  $NODUM/vaults/$VAULT/notes/$NOTE/links
+```
+
+```json
+{ "data": { "from": "0198…", "to": "0198…",
+            "inserted": "- [[Learning]]", "already_linked": false } }
+```
+
+`target` is an id, a path, or an exact title. Already linked? Nothing is
+written and `already_linked` is `true` — safe to retry. `context` puts the
+link in a sentence: `{"target": "…", "context": "Follows from {link}."}`.
+When two notes share a title the API writes the path form (`[[Topics/…]]`)
+— and if you *say* only the ambiguous title, it answers `422` naming a path
+rather than guessing.
+
+## Unlink — `DELETE /vaults/{id}/notes/{note_id}/links?target=…` *(write)*
+
+Links *are* the `[[wikilinks]]` in the markdown, so unlinking edits the
+markdown: every prose link that unambiguously means the target is spliced
+out, and `{"removed": n}` says how many. Embeds (`![[…]]`) and links inside
+code are content, not connections — they stay. `removed: 0` still succeeds.
+
+## Reading the connections
+
+- `GET …/notes/{id}/backlinks` — who links *here*:
+  `{"backlinks": [{note_id, title, path, count, snippets: ["…the sentence around the link…"]}]}`.
+- `GET …/notes/{id}/links` — links *from* here, resolved and unresolved.
+- `GET …/notes/{id}/unlinked-mentions` — notes that mention this title
+  without linking it: the "you should probably link these" list.
+
+## Tags
+
+- `GET /vaults/{id}/tags` — `[{name, count}]`, most used first.
+- `GET /vaults/{id}/tags/{name}` — notes carrying a tag; nested tags match
+  by prefix, so `projects` also finds `projects/api`.
+
+## The graph
+
+- `GET /vaults/{id}/graph` — the whole vault: `nodes` (notes and
+  unresolved `ghost:` targets, with degree and tags) and `edges` as
+  node-index pairs — the same data the in-app graph draws.
+- `GET /vaults/{id}/notes/{note_id}/graph?depth=2` — the neighborhood
+  around one note, 1–5 hops.
+
+## Ask the vault — `POST /vaults/{id}/ai/ask` *(ai)*
+
+```bash
+curl -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"message": "Summarise what my notes say about spaced repetition."}' \
+  $NODUM/vaults/$VAULT/ai/ask
+```
+
+Answers with `{conversation_id, title, reply, provider, model, actions}` —
+`reply` is markdown, `actions` lists any notes the assistant created or
+edited, and `conversation_id` continues the thread on the next call. Uses
+the provider configured in Settings → AI (none configured → `404`). The
+tool loop can take a while; give your client 120 s. And note the scope's
+teeth: the assistant's tools can *write*, so an `ai` key can change a vault
+even without `write`.

--- a/web/src/content/docs/api.md
+++ b/web/src/content/docs/api.md
@@ -1,7 +1,7 @@
 ---
 title: API — connect your own apps
-section: Extending
-order: 5
+section: Developers
+order: 1
 summary: Create an API key and drive your vaults from any language over plain REST — list, search, read, write, link, unlink, tag, graph, even ask the AI.
 where: Settings → API keys for the key and a ready-made curl
 ---
@@ -76,6 +76,13 @@ Auth box and requests run from the page, against your own vaults, with
 generated snippets for shell, Python, JavaScript and more.
 
 ![The interactive API reference: endpoints on the left, schemas and a try-it client on the right.](/docs/api-reference.png)
+
+## Going deeper
+
+Two guides walk every endpoint with copy-paste requests and real responses:
+[working with notes and files](/docs/api-notes) and
+[search, links, tags and the graph](/docs/api-search-links) — and
+[recipes](/docs/api-recipes) turns them into small working programs.
 
 ## Worth knowing
 

--- a/web/src/lib/docs.ts
+++ b/web/src/lib/docs.ts
@@ -50,6 +50,7 @@ export const DOC_SECTIONS = [
   "Organising",
   "Sharing",
   "Extending",
+  "Developers",
   "Account",
 ] as const;
 


### PR DESCRIPTION
A proper developer-docs suite in the landing-page docs section: the API overview joined by per-area endpoint guides (every endpoint with a working curl + real response JSON) and three executable recipes with least-privilege scope callouts. All examples validated against the live API; recipes executed end to end; docs/seo/api-keys e2e suites green (23/23) and make verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)