### PR TITLE
feat(community): S1.2 — anonymous read API

### DIFF
--- a/back/app/api/v1/community.py
+++ b/back/app/api/v1/community.py
@@ -1,0 +1,63 @@
+"""Community forum endpoints.
+
+The read side is anonymous — the forum is publicly readable like the docs,
+so these routes take no auth dependency at all (S1.2). Writes arrive in
+S1.3 under CurrentUserId.
+"""
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Query
+
+from app.dependencies.db import SessionDep
+from app.services import community_service
+
+router = APIRouter()
+
+
+@router.get("/categories")
+async def list_categories(db: SessionDep) -> dict[str, Any]:
+    """Every category with its counters, in rail order."""
+    return {"data": (await community_service.list_categories(db)).unwrap()}
+
+
+@router.get("/topics")
+async def list_topics(
+    db: SessionDep,
+    category: str | None = Query(default=None, description="A category slug; omit for all."),
+    top: str | None = Query(default=None, pattern="^(week|month|all)$", description="Top instead of Latest."),
+    limit: int = Query(default=30, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, Any]:
+    """Latest (default), Top (?top=week|month|all), optionally within a category
+    — where pinned topics float first."""
+    return {
+        "data": (
+            await community_service.list_topics(db, category_slug=category, top_window=top, limit=limit, offset=offset)
+        ).unwrap()
+    }
+
+
+@router.get("/topics/{topic_id}")
+async def get_topic(topic_id: UUID, db: SessionDep) -> dict[str, Any]:
+    return {"data": (await community_service.get_topic(db, topic_id)).unwrap()}
+
+
+@router.get("/topics/{topic_id}/posts")
+async def list_posts(
+    topic_id: UUID,
+    db: SessionDep,
+    after: int = Query(default=0, ge=0, description="The last post_number you have; 0 from the top."),
+    limit: int = Query(default=50, ge=1, le=100),
+) -> dict[str, Any]:
+    """The thread, keyset-paginated: ask again with `after` = the last
+    `post_number` received while `has_more` is true. Deleted posts are
+    placeholders — the numbering never shifts under you."""
+    return {"data": (await community_service.list_posts(db, topic_id, after=after, limit=limit)).unwrap()}
+
+
+@router.get("/users/{user_id}")
+async def get_profile(user_id: UUID, db: SessionDep) -> dict[str, Any]:
+    """A member's public profile: identity, join date, forum stats, recent topics."""
+    return {"data": (await community_service.get_profile(db, user_id)).unwrap()}

--- a/back/app/api/v1/router.py
+++ b/back/app/api/v1/router.py
@@ -15,6 +15,7 @@ from app.api.v1 import (
     canvases,
     clipper,
     collab,
+    community,
     daily,
     folders,
     links,
@@ -49,3 +50,4 @@ api_router.include_router(canvases.router, prefix="/vaults/{vault_id}/canvases",
 api_router.include_router(ai.router, prefix="/ai", tags=["AI"])
 api_router.include_router(mcp_tokens.router, prefix="/mcp-tokens", tags=["MCP"])
 api_router.include_router(api_keys.router, prefix="/api-keys", tags=["API keys"])
+api_router.include_router(community.router, prefix="/community", tags=["Community"])

--- a/back/app/services/community_service.py
+++ b/back/app/services/community_service.py
@@ -1,0 +1,244 @@
+"""Community forum service — the read paths (S1.2).
+
+Everything here is answerable by an anonymous visitor, so no function takes
+a viewer id: viewer-dependent decoration (unread chips, own-likes) joins in
+later, additively. Lists use offset+window-count pagination with an id
+tie-break and an honest total past the end (the note_service pattern);
+threads use keyset pagination on (topic_id, post_number) — a topic can be
+thousands of posts deep and OFFSET degrades linearly.
+"""
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.community import CommunityCategory, CommunityPost, CommunityTopic
+from app.services.service_response import ServiceResponse
+from app.utils.cache_utils import cache_delete, cache_get_json, cache_set_json
+
+CATEGORIES_CACHE_KEY = "community:categories:v1"
+_CATEGORIES_TTL_SECONDS = 60
+
+TOP_WINDOWS: dict[str, int | None] = {"week": 7, "month": 30, "all": None}
+
+
+def _author(user_id: UUID | None, name: str | None, avatar_url: str | None) -> dict[str, Any] | None:
+    """A post's public byline — or None for a deleted account."""
+    if user_id is None:
+        return None
+    return {"id": str(user_id), "name": name or "Someone", "avatar_url": avatar_url}
+
+
+def _category(c: CommunityCategory) -> dict[str, Any]:
+    return {
+        "id": str(c.id),
+        "name": c.name,
+        "slug": c.slug,
+        "description": c.description,
+        "position": c.position,
+        "is_staff_only_posting": c.is_staff_only_posting,
+        "topic_count": c.topic_count,
+        "post_count": c.post_count,
+    }
+
+
+def _topic(t: CommunityTopic, author: dict[str, Any] | None, category_slug: str | None = None) -> dict[str, Any]:
+    out = {
+        "id": str(t.id),
+        "category_id": str(t.category_id),
+        "title": t.title,
+        "slug": t.slug,
+        "author": author,
+        "is_pinned": t.is_pinned,
+        "is_locked": t.is_locked,
+        "reply_count": t.reply_count,
+        "last_post_number": t.last_post_number,
+        "view_count": t.view_count,
+        "created_at": t.created_at.isoformat(),
+        "last_post_at": t.last_post_at.isoformat(),
+    }
+    if category_slug is not None:
+        out["category_slug"] = category_slug
+    return out
+
+
+async def list_categories(db: AsyncSession) -> ServiceResponse[list[dict[str, Any]]]:
+    """The category rail — cached briefly: it changes only when staff post
+    counts tick, and every visitor hits it."""
+    cached = await cache_get_json(CATEGORIES_CACHE_KEY)
+    if cached is not None:
+        return ServiceResponse.ok(cached)
+    rows = (await db.execute(select(CommunityCategory).order_by(CommunityCategory.position))).scalars().all()
+    data = [_category(c) for c in rows]
+    await cache_set_json(CATEGORIES_CACHE_KEY, data, ttl_seconds=_CATEGORIES_TTL_SECONDS)
+    return ServiceResponse.ok(data)
+
+
+async def invalidate_categories_cache() -> None:
+    await cache_delete(CATEGORIES_CACHE_KEY)
+
+
+async def get_category(db: AsyncSession, slug: str) -> ServiceResponse[CommunityCategory]:
+    category = await db.scalar(select(CommunityCategory).where(CommunityCategory.slug == slug))
+    if category is None:
+        return ServiceResponse.fail("not_found", "Category not found.")
+    return ServiceResponse.ok(category)
+
+
+async def list_topics(
+    db: AsyncSession,
+    *,
+    category_slug: str | None = None,
+    top_window: str | None = None,
+    limit: int = 30,
+    offset: int = 0,
+) -> ServiceResponse[dict[str, Any]]:
+    """Topic lists: a category page (pinned first), Latest, or Top.
+
+    Top is deliberately simple: most replies within the window — a filter
+    and an order over indexed columns, not a scoring engine.
+    """
+    stmt = (
+        select(CommunityTopic, User.name, User.avatar_url, CommunityCategory.slug, func.count().over().label("total"))
+        .outerjoin(User, User.id == CommunityTopic.author_id)
+        .join(CommunityCategory, CommunityCategory.id == CommunityTopic.category_id)
+        .where(CommunityTopic.is_deleted.is_(False))
+    )
+    count_filters = [CommunityTopic.is_deleted.is_(False)]
+
+    category: CommunityCategory | None = None
+    if category_slug is not None:
+        cat_res = await get_category(db, category_slug)
+        if not cat_res.success:
+            return cat_res  # type: ignore[return-value]
+        category = cat_res.data
+        assert category is not None
+        stmt = stmt.where(CommunityTopic.category_id == category.id)
+        count_filters.append(CommunityTopic.category_id == category.id)
+
+    if top_window is not None:
+        if top_window not in TOP_WINDOWS:
+            return ServiceResponse.fail("validation_failed", 'top must be "week", "month" or "all".')
+        days = TOP_WINDOWS[top_window]
+        if days is not None:
+            cutoff = func.now() - func.make_interval(0, 0, 0, days)
+            stmt = stmt.where(CommunityTopic.last_post_at >= cutoff)
+            count_filters.append(CommunityTopic.last_post_at >= cutoff)
+        stmt = stmt.order_by(
+            CommunityTopic.reply_count.desc(), CommunityTopic.last_post_at.desc(), CommunityTopic.id.desc()
+        )
+    elif category is not None:
+        stmt = stmt.order_by(
+            CommunityTopic.is_pinned.desc(), CommunityTopic.last_post_at.desc(), CommunityTopic.id.desc()
+        )
+    else:
+        stmt = stmt.order_by(CommunityTopic.last_post_at.desc(), CommunityTopic.id.desc())
+
+    rows = (await db.execute(stmt.limit(limit).offset(offset))).all()
+    if rows:
+        total = int(rows[0].total)
+    elif offset:
+        total = int(await db.scalar(select(func.count()).select_from(CommunityTopic).where(*count_filters)) or 0)
+    else:
+        total = 0
+    items = [_topic(t, _author(t.author_id, name, avatar), slug) for t, name, avatar, slug, _ in rows]
+    return ServiceResponse.ok({"items": items, "total": total, "limit": limit, "offset": offset})
+
+
+async def get_topic(db: AsyncSession, topic_id: UUID) -> ServiceResponse[dict[str, Any]]:
+    row = (
+        await db.execute(
+            select(CommunityTopic, User.name, User.avatar_url, CommunityCategory.slug)
+            .outerjoin(User, User.id == CommunityTopic.author_id)
+            .join(CommunityCategory, CommunityCategory.id == CommunityTopic.category_id)
+            .where(CommunityTopic.id == topic_id, CommunityTopic.is_deleted.is_(False))
+        )
+    ).first()
+    if row is None:
+        return ServiceResponse.fail("not_found", "Topic not found.")
+    t, name, avatar, category_slug = row
+    return ServiceResponse.ok(_topic(t, _author(t.author_id, name, avatar), category_slug))
+
+
+async def list_posts(
+    db: AsyncSession, topic_id: UUID, *, after: int = 0, limit: int = 50
+) -> ServiceResponse[dict[str, Any]]:
+    """A topic's posts, keyset-paginated by post_number (`after` = the last
+    number the client has). Soft-deleted posts come back as placeholders —
+    the row keeps its number so the thread's shape survives moderation."""
+    topic = await db.scalar(
+        select(CommunityTopic.id).where(CommunityTopic.id == topic_id, CommunityTopic.is_deleted.is_(False))
+    )
+    if topic is None:
+        return ServiceResponse.fail("not_found", "Topic not found.")
+    rows = (
+        await db.execute(
+            select(CommunityPost, User.name, User.avatar_url)
+            .outerjoin(User, User.id == CommunityPost.author_id)
+            .where(CommunityPost.topic_id == topic_id, CommunityPost.post_number > after)
+            .order_by(CommunityPost.post_number)
+            .limit(limit + 1)  # the sentinel row answers has_more without a count
+        )
+    ).all()
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    items = []
+    for p, name, avatar in rows:
+        if p.is_deleted:
+            items.append({"id": str(p.id), "post_number": p.post_number, "is_deleted": True})
+            continue
+        items.append(
+            {
+                "id": str(p.id),
+                "post_number": p.post_number,
+                "author": _author(p.author_id, name, avatar),
+                "content": p.content,
+                "like_count": p.like_count,
+                "edited_at": p.edited_at.isoformat() if p.edited_at else None,
+                "created_at": p.created_at.isoformat(),
+                "is_deleted": False,
+            }
+        )
+    return ServiceResponse.ok({"items": items, "has_more": has_more, "limit": limit, "after": after})
+
+
+async def get_profile(db: AsyncSession, user_id: UUID) -> ServiceResponse[dict[str, Any]]:
+    """A public profile: identity + forum stats, all from indexed counts."""
+    user = await db.scalar(select(User).where(User.id == user_id, User.is_active.is_(True)))
+    if user is None:
+        return ServiceResponse.fail("not_found", "User not found.")
+    topic_count = await db.scalar(
+        select(func.count())
+        .select_from(CommunityTopic)
+        .where(CommunityTopic.author_id == user_id, CommunityTopic.is_deleted.is_(False))
+    )
+    post_count = await db.scalar(
+        select(func.count())
+        .select_from(CommunityPost)
+        .where(CommunityPost.author_id == user_id, CommunityPost.is_deleted.is_(False))
+    )
+    recent = (
+        await db.execute(
+            select(CommunityTopic, CommunityCategory.slug)
+            .join(CommunityCategory, CommunityCategory.id == CommunityTopic.category_id)
+            .where(CommunityTopic.author_id == user_id, CommunityTopic.is_deleted.is_(False))
+            .order_by(CommunityTopic.created_at.desc())
+            .limit(10)
+        )
+    ).all()
+    author = _author(user.id, user.name, user.avatar_url)
+    return ServiceResponse.ok(
+        {
+            "id": str(user.id),
+            "name": user.name,
+            "avatar_url": user.avatar_url,
+            "is_staff": user.is_staff,
+            "joined_at": user.created_at.isoformat(),
+            "topic_count": int(topic_count or 0),
+            "post_count": int(post_count or 0),
+            "recent_topics": [_topic(t, author, slug) for t, slug in recent],
+        }
+    )

--- a/back/tests/integration/test_community.py
+++ b/back/tests/integration/test_community.py
@@ -1,7 +1,12 @@
-"""Community forum, driven over HTTP. Started in S1.1 with the foundations:
-the migration's seeds, and is_staff riding the auth payload."""
+"""Community forum, driven over HTTP.
+
+S1.1: the migration's seeds and is_staff riding the auth payload.
+S1.2: the anonymous read surface — until the write API lands in S1.3,
+fixtures insert rows through the ORM.
+"""
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
 from httpx import AsyncClient
 
@@ -36,3 +41,137 @@ async def test_auth_me_carries_is_staff(client: AsyncClient) -> None:
     me = await client.get("/api/v1/auth/me", headers=session)
     assert me.status_code == 200, me.text
     assert me.json()["data"]["is_staff"] is False
+
+
+async def _seed_forum(n_topics: int = 3, posts_in_first: int = 5) -> dict:
+    """Topics in Help by a real user, the first with a chain of replies."""
+    from sqlalchemy import select
+
+    from app.core.db import async_session_factory
+    from app.models.auth import User
+    from app.models.community import CommunityCategory, CommunityPost, CommunityTopic
+    from app.utils.slug_utils import slugify
+
+    marker = uuid.uuid4().hex[:8]
+    async with async_session_factory() as db:
+        help_cat = await db.scalar(select(CommunityCategory).where(CommunityCategory.slug == "help"))
+        assert help_cat is not None
+        user = User(
+            email=f"seed-{marker}@nodumtest.dev", password_hash="x", name=f"Seeder {marker}", email_verified=True
+        )
+        db.add(user)
+        await db.flush()
+        topics = []
+        base = datetime.now(UTC)
+        for i in range(n_topics):
+            title = f"Seed {marker} topic {i}"
+            topic = CommunityTopic(
+                category_id=help_cat.id,
+                author_id=user.id,
+                title=title,
+                slug=slugify(title),
+                last_post_at=base + timedelta(minutes=i),
+            )
+            db.add(topic)
+            await db.flush()
+            db.add(CommunityPost(topic_id=topic.id, author_id=user.id, post_number=1, content=f"OP of {title}"))
+            topics.append(topic)
+        first = topics[0]
+        for n in range(2, posts_in_first + 2):
+            db.add(CommunityPost(topic_id=first.id, author_id=user.id, post_number=n, content=f"Reply {n}"))
+        first.reply_count = posts_in_first
+        first.last_post_number = posts_in_first + 1
+        await db.commit()
+        return {
+            "marker": marker,
+            "user_id": str(user.id),
+            "topic_ids": [str(t.id) for t in topics],
+        }
+
+
+async def test_anonymous_reads_work_without_any_header(client: AsyncClient) -> None:
+    seed = await _seed_forum()
+    cats = await client.get("/api/v1/community/categories")
+    assert cats.status_code == 200 and len(cats.json()["data"]) == 5
+
+    latest = await client.get("/api/v1/community/topics", params={"limit": 100})
+    assert latest.status_code == 200
+    titles = [t["title"] for t in latest.json()["data"]["items"]]
+    assert f"Seed {seed['marker']} topic 2" in titles
+
+    in_help = await client.get("/api/v1/community/topics", params={"category": "help", "limit": 100})
+    assert in_help.status_code == 200
+    assert all(t["category_slug"] == "help" for t in in_help.json()["data"]["items"])
+
+    topic = await client.get(f"/api/v1/community/topics/{seed['topic_ids'][0]}")
+    assert topic.status_code == 200
+    assert topic.json()["data"]["author"]["name"].startswith("Seeder")
+
+    profile = await client.get(f"/api/v1/community/users/{seed['user_id']}")
+    assert profile.status_code == 200
+    body = profile.json()["data"]
+    assert body["topic_count"] == 3 and body["post_count"] == 8
+
+
+async def test_topic_list_pagination_is_honest(client: AsyncClient) -> None:
+    seed = await _seed_forum(n_topics=3, posts_in_first=0)
+    first = await client.get("/api/v1/community/topics", params={"category": "help", "limit": 2})
+    data = first.json()["data"]
+    assert data["total"] >= 3 and len(data["items"]) == 2
+    past = await client.get(
+        "/api/v1/community/topics", params={"category": "help", "limit": 2, "offset": data["total"] + 50}
+    )
+    body = past.json()["data"]
+    assert body["items"] == [] and body["total"] == data["total"], "total stays honest past the end"
+    assert seed["marker"]  # seed used
+
+
+async def test_thread_keyset_pagination_never_repeats_or_skips(client: AsyncClient) -> None:
+    seed = await _seed_forum(n_topics=1, posts_in_first=7)  # 8 posts incl. OP
+    tid = seed["topic_ids"][0]
+    seen: list[int] = []
+    after = 0
+    for _ in range(5):
+        page = (await client.get(f"/api/v1/community/topics/{tid}/posts", params={"after": after, "limit": 3})).json()[
+            "data"
+        ]
+        seen += [p["post_number"] for p in page["items"]]
+        if not page["has_more"]:
+            break
+        after = page["items"][-1]["post_number"]
+    assert seen == list(range(1, 9)), seen
+
+
+async def test_deleted_posts_are_placeholders_and_deleted_topics_404(client: AsyncClient) -> None:
+    from sqlalchemy import update
+
+    from app.core.db import async_session_factory
+    from app.models.community import CommunityPost, CommunityTopic
+
+    seed = await _seed_forum(n_topics=2, posts_in_first=2)
+    tid = seed["topic_ids"][0]
+    async with async_session_factory() as db:
+        await db.execute(
+            update(CommunityPost)
+            .where(CommunityPost.topic_id == tid, CommunityPost.post_number == 2)
+            .values(is_deleted=True)
+        )
+        await db.execute(
+            update(CommunityTopic).where(CommunityTopic.id == seed["topic_ids"][1]).values(is_deleted=True)
+        )
+        await db.commit()
+
+    page = (await client.get(f"/api/v1/community/topics/{tid}/posts")).json()["data"]
+    ghost = next(p for p in page["items"] if p["post_number"] == 2)
+    assert ghost["is_deleted"] is True and "content" not in ghost
+    assert [p["post_number"] for p in page["items"]] == [1, 2, 3], "numbering survives moderation"
+
+    gone = await client.get(f"/api/v1/community/topics/{seed['topic_ids'][1]}")
+    assert gone.status_code == 404
+    unknown = await client.get(f"/api/v1/community/topics/{uuid.uuid4()}")
+    assert unknown.status_code == 404 and unknown.json()["error"]["code"] == "not_found"
+
+
+async def test_top_rejects_unknown_window(client: AsyncClient) -> None:
+    resp = await client.get("/api/v1/community/topics", params={"top": "decade"})
+    assert resp.status_code == 422


### PR DESCRIPTION
Categories (briefly cached), topic lists (Latest/Top/category with pinned-first and honest totals), keyset-paginated threads with moderation-safe placeholders, and public profiles — no route takes auth. Seven integration tests drive it anonymously. Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)