### PR TITLE
feat(community): S1.3 — write API

### DIFF
--- a/back/app/api/v1/community.py
+++ b/back/app/api/v1/community.py
@@ -1,19 +1,35 @@
 """Community forum endpoints.
 
 The read side is anonymous — the forum is publicly readable like the docs,
-so these routes take no auth dependency at all (S1.2). Writes arrive in
-S1.3 under CurrentUserId.
+so those routes take no auth dependency at all. Writes require a session
+(CurrentUserId); ownership and staff rules live in the service.
 """
 
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, status
+from pydantic import BaseModel, Field
 
+from app.dependencies.auth import CurrentUserId
 from app.dependencies.db import SessionDep
 from app.services import community_service
 
 router = APIRouter()
+
+
+class TopicCreateRequest(BaseModel):
+    category: str = Field(min_length=1, max_length=100, description="Category slug.")
+    title: str = Field(min_length=1, max_length=300)
+    content: str = Field(min_length=1)
+
+
+class PostCreateRequest(BaseModel):
+    content: str = Field(min_length=1)
+
+
+class PostEditRequest(BaseModel):
+    content: str = Field(min_length=1)
 
 
 @router.get("/categories")
@@ -61,3 +77,44 @@ async def list_posts(
 async def get_profile(user_id: UUID, db: SessionDep) -> dict[str, Any]:
     """A member's public profile: identity, join date, forum stats, recent topics."""
     return {"data": (await community_service.get_profile(db, user_id)).unwrap()}
+
+
+# ── Writes ───────────────────────────────────────────────────────────────────
+
+
+@router.post("/topics", status_code=status.HTTP_201_CREATED)
+async def create_topic(body: TopicCreateRequest, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Start a topic (the content becomes its opening post)."""
+    return {
+        "data": (
+            await community_service.create_topic(
+                db, user_id, category_slug=body.category, title=body.title, content=body.content
+            )
+        ).unwrap()
+    }
+
+
+@router.post("/topics/{topic_id}/posts", status_code=status.HTTP_201_CREATED)
+async def create_post(
+    topic_id: UUID, body: PostCreateRequest, user_id: CurrentUserId, db: SessionDep
+) -> dict[str, Any]:
+    """Reply to a topic."""
+    return {"data": (await community_service.create_post(db, user_id, topic_id, content=body.content)).unwrap()}
+
+
+@router.patch("/posts/{post_id}")
+async def edit_post(post_id: UUID, body: PostEditRequest, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Edit your own post (marks it edited)."""
+    return {"data": (await community_service.edit_post(db, user_id, post_id, content=body.content)).unwrap()}
+
+
+@router.delete("/posts/{post_id}")
+async def delete_post(post_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Delete your own reply (a numbered placeholder remains)."""
+    return {"data": (await community_service.delete_post(db, user_id, post_id)).unwrap()}
+
+
+@router.delete("/topics/{topic_id}")
+async def delete_topic(topic_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Delete your own topic — only while nobody has replied."""
+    return {"data": (await community_service.delete_topic(db, user_id, topic_id)).unwrap()}

--- a/back/app/services/community_service.py
+++ b/back/app/services/community_service.py
@@ -242,3 +242,234 @@ async def get_profile(db: AsyncSession, user_id: UUID) -> ServiceResponse[dict[s
             "recent_topics": [_topic(t, author, slug) for t, slug in recent],
         }
     )
+
+
+# ── Writes (S1.3) ────────────────────────────────────────────────────────────
+#
+# Every counter bump is an atomic `SET x = x ± 1` executed inside the same
+# transaction as the row it counts, under the topic FOR UPDATE lock that
+# post-number assignment already needs — the counters cannot drift.
+
+
+async def _check_rate(
+    user_id: UUID, action: str, *, limit: int, window_seconds: int, gap_seconds: int = 0
+) -> str | None:
+    """Fixed-window per-user throttle + minimum gap. Fail-open (Redis down →
+    allowed), disabled in dev/test like the global limiter. Returns an error
+    message, or None to proceed."""
+    from app.settings import get_settings
+
+    if get_settings().ENVIRONMENT in ("dev", "test"):
+        return None
+    try:
+        from app.core.redis import redis_control
+
+        if gap_seconds:
+            gap_key = f"rl:community:gap:{action}:{user_id}"
+            if not await redis_control.set(gap_key, "1", ex=gap_seconds, nx=True):
+                return f"Give it {gap_seconds} seconds between {action}s."
+        key = f"rl:community:{action}:{user_id}"
+        count = await redis_control.incr(key)
+        if count == 1:
+            await redis_control.expire(key, window_seconds)
+        if count > limit:
+            return f"That is plenty of {action}s for now — try again in a while."
+    except Exception:
+        return None
+    return None
+
+
+def _clean_content(content: str) -> ServiceResponse[str] | str:
+    from app.settings import get_settings
+
+    content = content.strip()
+    if not content:
+        return ServiceResponse.fail("validation_failed", "Write something first.")
+    if len(content) > get_settings().COMMUNITY_POST_MAX_CHARS:
+        return ServiceResponse.fail(
+            "validation_failed", f"Posts cap at {get_settings().COMMUNITY_POST_MAX_CHARS:,} characters."
+        )
+    return content
+
+
+async def create_topic(
+    db: AsyncSession, user_id: UUID, *, category_slug: str, title: str, content: str
+) -> ServiceResponse[dict[str, Any]]:
+    from app.utils.slug_utils import slugify
+
+    title = title.strip()
+    if not 3 <= len(title) <= 300:
+        return ServiceResponse.fail("validation_failed", "Titles run 3 to 300 characters.")
+    cleaned = _clean_content(content)
+    if isinstance(cleaned, ServiceResponse):
+        return cleaned
+    cat_res = await get_category(db, category_slug)
+    if not cat_res.success:
+        return cat_res  # type: ignore[return-value]
+    category = cat_res.data
+    assert category is not None
+    if category.is_staff_only_posting:
+        user = await db.scalar(select(User).where(User.id == user_id))
+        if user is None or not user.is_staff:
+            return ServiceResponse.fail("forbidden", f"Only staff post in {category.name}.")
+    if err := await _check_rate(user_id, "topic", limit=5, window_seconds=3600, gap_seconds=30):
+        return ServiceResponse.fail("rate_limited", err)
+
+    topic = CommunityTopic(
+        category_id=category.id,
+        author_id=user_id,
+        title=title,
+        slug=slugify(title),
+        last_post_author_id=user_id,
+    )
+    db.add(topic)
+    await db.flush()
+    db.add(CommunityPost(topic_id=topic.id, author_id=user_id, post_number=1, content=cleaned))
+    await db.execute(
+        CommunityCategory.__table__.update()
+        .where(CommunityCategory.id == category.id)
+        .values(topic_count=CommunityCategory.topic_count + 1, post_count=CommunityCategory.post_count + 1)
+    )
+    await db.commit()
+    await invalidate_categories_cache()
+    return await get_topic(db, topic.id)
+
+
+async def create_post(
+    db: AsyncSession, user_id: UUID, topic_id: UUID, *, content: str
+) -> ServiceResponse[dict[str, Any]]:
+    cleaned = _clean_content(content)
+    if isinstance(cleaned, ServiceResponse):
+        return cleaned
+    if err := await _check_rate(user_id, "post", limit=30, window_seconds=3600, gap_seconds=10):
+        return ServiceResponse.fail("rate_limited", err)
+
+    # The lock serialises number assignment AND every counter this touches.
+    topic = await db.scalar(
+        select(CommunityTopic)
+        .where(CommunityTopic.id == topic_id, CommunityTopic.is_deleted.is_(False))
+        .with_for_update()
+    )
+    if topic is None:
+        return ServiceResponse.fail("not_found", "Topic not found.")
+    if topic.is_locked:
+        return ServiceResponse.fail("conflict", "This topic is locked.")
+
+    number = topic.last_post_number + 1
+    post = CommunityPost(topic_id=topic.id, author_id=user_id, post_number=number, content=cleaned)
+    db.add(post)
+    topic.last_post_number = number
+    topic.reply_count = topic.reply_count + 1
+    topic.last_post_at = func.now()
+    topic.last_post_author_id = user_id
+    await db.execute(
+        CommunityCategory.__table__.update()
+        .where(CommunityCategory.id == topic.category_id)
+        .values(post_count=CommunityCategory.post_count + 1)
+    )
+    await db.commit()
+    await db.refresh(post)
+    return ServiceResponse.ok(
+        {
+            "id": str(post.id),
+            "topic_id": str(topic.id),
+            "post_number": post.post_number,
+            "content": post.content,
+            "created_at": post.created_at.isoformat(),
+        }
+    )
+
+
+async def edit_post(db: AsyncSession, user_id: UUID, post_id: UUID, *, content: str) -> ServiceResponse[dict[str, Any]]:
+    """Authors edit their own posts; staff editing is deliberately absent —
+    staff delete, they do not rewrite other people's words."""
+    cleaned = _clean_content(content)
+    if isinstance(cleaned, ServiceResponse):
+        return cleaned
+    post = await db.scalar(
+        select(CommunityPost).where(CommunityPost.id == post_id, CommunityPost.is_deleted.is_(False))
+    )
+    if post is None:
+        return ServiceResponse.fail("not_found", "Post not found.")
+    if post.author_id != user_id:
+        return ServiceResponse.fail("forbidden", "Only the author edits a post.")
+    topic_locked = await db.scalar(select(CommunityTopic.is_locked).where(CommunityTopic.id == post.topic_id))
+    if topic_locked:
+        return ServiceResponse.fail("conflict", "This topic is locked.")
+    post.content = cleaned
+    post.edited_at = func.now()
+    await db.commit()
+    await db.refresh(post)
+    return ServiceResponse.ok(
+        {
+            "id": str(post.id),
+            "post_number": post.post_number,
+            "content": post.content,
+            "edited_at": post.edited_at.isoformat() if post.edited_at else None,
+        }
+    )
+
+
+async def delete_post(
+    db: AsyncSession, user_id: UUID, post_id: UUID, *, as_staff: bool = False
+) -> ServiceResponse[dict[str, Any]]:
+    """Soft delete. The OP (post 1) cannot go alone — delete the topic.
+
+    Takes the topic lock first: the reply-count decrement must not race a
+    concurrent reply's increment."""
+    post = await db.scalar(
+        select(CommunityPost).where(CommunityPost.id == post_id, CommunityPost.is_deleted.is_(False))
+    )
+    if post is None:
+        return ServiceResponse.fail("not_found", "Post not found.")
+    if not as_staff and post.author_id != user_id:
+        return ServiceResponse.fail("forbidden", "Only the author (or staff) deletes a post.")
+    if post.post_number == 1:
+        return ServiceResponse.fail("validation_failed", "The opening post is the topic — delete the topic instead.")
+    topic = await db.scalar(select(CommunityTopic).where(CommunityTopic.id == post.topic_id).with_for_update())
+    assert topic is not None
+    post.is_deleted = True
+    topic.reply_count = topic.reply_count - 1  # last_post_number NEVER decrements
+    await db.execute(
+        CommunityCategory.__table__.update()
+        .where(CommunityCategory.id == topic.category_id)
+        .values(post_count=CommunityCategory.post_count - 1)
+    )
+    await db.commit()
+    return ServiceResponse.ok({"deleted": str(post_id)})
+
+
+async def delete_topic(
+    db: AsyncSession, user_id: UUID, topic_id: UUID, *, as_staff: bool = False
+) -> ServiceResponse[dict[str, Any]]:
+    """Soft delete a whole topic. Authors may while it has no replies —
+    after someone answered, the thread belongs to the conversation (staff only)."""
+    topic = await db.scalar(
+        select(CommunityTopic)
+        .where(CommunityTopic.id == topic_id, CommunityTopic.is_deleted.is_(False))
+        .with_for_update()
+    )
+    if topic is None:
+        return ServiceResponse.fail("not_found", "Topic not found.")
+    if not as_staff:
+        if topic.author_id != user_id:
+            return ServiceResponse.fail("forbidden", "Only the author (or staff) deletes a topic.")
+        if topic.reply_count > 0:
+            return ServiceResponse.fail("conflict", "People have replied — the thread is theirs too now. Ask staff.")
+    live_posts = await db.scalar(
+        select(func.count())
+        .select_from(CommunityPost)
+        .where(CommunityPost.topic_id == topic.id, CommunityPost.is_deleted.is_(False))
+    )
+    topic.is_deleted = True
+    await db.execute(
+        CommunityCategory.__table__.update()
+        .where(CommunityCategory.id == topic.category_id)
+        .values(
+            topic_count=CommunityCategory.topic_count - 1,
+            post_count=CommunityCategory.post_count - int(live_posts or 0),
+        )
+    )
+    await db.commit()
+    await invalidate_categories_cache()
+    return ServiceResponse.ok({"deleted": str(topic_id)})

--- a/back/tests/integration/test_community.py
+++ b/back/tests/integration/test_community.py
@@ -175,3 +175,155 @@ async def test_deleted_posts_are_placeholders_and_deleted_topics_404(client: Asy
 async def test_top_rejects_unknown_window(client: AsyncClient) -> None:
     resp = await client.get("/api/v1/community/topics", params={"top": "decade"})
     assert resp.status_code == 422
+
+
+# ── S1.3: the write API ──────────────────────────────────────────────────────
+
+
+async def _post_topic(client: AsyncClient, headers: dict, title: str, category: str = "help") -> dict:
+    resp = await client.post(
+        "/api/v1/community/topics",
+        json={"category": category, "title": title, "content": f"OP for {title}"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["data"]
+
+
+async def test_topic_and_reply_lifecycle(client: AsyncClient) -> None:
+    author = await _signup(client, "author")
+    marker = uuid.uuid4().hex[:8]
+    topic = await _post_topic(client, author, f"Lifecycle {marker}")
+    assert topic["reply_count"] == 0 and topic["last_post_number"] == 1
+
+    anonymous_denied = await client.post(f"/api/v1/community/topics/{topic['id']}/posts", json={"content": "hi"})
+    assert anonymous_denied.status_code == 401
+
+    reply = await client.post(
+        f"/api/v1/community/topics/{topic['id']}/posts", json={"content": "First answer."}, headers=author
+    )
+    assert reply.status_code == 201 and reply.json()["data"]["post_number"] == 2
+
+    refreshed = (await client.get(f"/api/v1/community/topics/{topic['id']}")).json()["data"]
+    assert refreshed["reply_count"] == 1 and refreshed["last_post_number"] == 2
+
+    edited = await client.patch(
+        f"/api/v1/community/posts/{reply.json()['data']['id']}", json={"content": "Better answer."}, headers=author
+    )
+    assert edited.status_code == 200 and edited.json()["data"]["edited_at"] is not None
+
+    gone = await client.delete(f"/api/v1/community/posts/{reply.json()['data']['id']}", headers=author)
+    assert gone.status_code == 200
+    after = (await client.get(f"/api/v1/community/topics/{topic['id']}")).json()["data"]
+    assert after["reply_count"] == 0
+    assert after["last_post_number"] == 2, "numbers never come back"
+
+    # Replyless again → the author may delete the whole topic.
+    assert (await client.delete(f"/api/v1/community/topics/{topic['id']}", headers=author)).status_code == 200
+    assert (await client.get(f"/api/v1/community/topics/{topic['id']}")).status_code == 404
+
+
+async def test_only_the_author_touches_a_post(client: AsyncClient) -> None:
+    author = await _signup(client, "owner")
+    stranger = await _signup(client, "stranger")
+    topic = await _post_topic(client, author, f"Ownership {uuid.uuid4().hex[:8]}")
+    reply = (
+        await client.post(f"/api/v1/community/topics/{topic['id']}/posts", json={"content": "mine"}, headers=author)
+    ).json()["data"]
+
+    for attempt in (
+        client.patch(f"/api/v1/community/posts/{reply['id']}", json={"content": "defaced"}, headers=stranger),
+        client.delete(f"/api/v1/community/posts/{reply['id']}", headers=stranger),
+        client.delete(f"/api/v1/community/topics/{topic['id']}", headers=stranger),
+    ):
+        resp = await attempt
+        assert resp.status_code == 403, resp.text
+
+    # After a reply exists, even the author cannot delete the topic.
+    assert (await client.delete(f"/api/v1/community/topics/{topic['id']}", headers=author)).status_code == 409
+
+
+async def test_locked_and_staff_only_and_caps(client: AsyncClient) -> None:
+    from sqlalchemy import update
+
+    from app.core.db import async_session_factory
+    from app.models.community import CommunityTopic
+
+    user = await _signup(client, "rules")
+    topic = await _post_topic(client, user, f"Rules {uuid.uuid4().hex[:8]}")
+
+    async with async_session_factory() as db:
+        await db.execute(update(CommunityTopic).where(CommunityTopic.id == topic["id"]).values(is_locked=True))
+        await db.commit()
+    locked = await client.post(
+        f"/api/v1/community/topics/{topic['id']}/posts", json={"content": "too late"}, headers=user
+    )
+    assert locked.status_code == 409 and "locked" in locked.json()["error"]["message"]
+
+    staff_only = await client.post(
+        "/api/v1/community/topics",
+        json={"category": "announcements", "title": "Not staff", "content": "hi"},
+        headers=user,
+    )
+    assert staff_only.status_code == 403
+
+    from app.settings import get_settings
+
+    over_cap = await client.post(
+        "/api/v1/community/topics",
+        json={"category": "help", "title": "Big", "content": "x" * (get_settings().COMMUNITY_POST_MAX_CHARS + 1)},
+        headers=user,
+    )
+    assert over_cap.status_code == 422
+
+    tiny_title = await client.post(
+        "/api/v1/community/topics", json={"category": "help", "title": "ab", "content": "hi"}, headers=user
+    )
+    assert tiny_title.status_code == 422
+
+    ghost_category = await client.post(
+        "/api/v1/community/topics", json={"category": "nope", "title": "Where", "content": "hi"}, headers=user
+    )
+    assert ghost_category.status_code == 404
+
+
+async def test_concurrent_replies_get_distinct_numbers(client: AsyncClient) -> None:
+    import asyncio
+
+    user = await _signup(client, "race")
+    topic = await _post_topic(client, user, f"Race {uuid.uuid4().hex[:8]}")
+
+    async def reply(i: int):
+        return await client.post(
+            f"/api/v1/community/topics/{topic['id']}/posts", json={"content": f"racer {i}"}, headers=user
+        )
+
+    results = await asyncio.gather(*[reply(i) for i in range(6)])
+    assert all(r.status_code == 201 for r in results)
+    numbers = sorted(r.json()["data"]["post_number"] for r in results)
+    assert numbers == [2, 3, 4, 5, 6, 7], numbers
+    refreshed = (await client.get(f"/api/v1/community/topics/{topic['id']}")).json()["data"]
+    assert refreshed["reply_count"] == 6 and refreshed["last_post_number"] == 7
+
+
+async def test_category_counters_track_the_truth(client: AsyncClient) -> None:
+    user = await _signup(client, "count")
+    before = next(
+        c for c in (await client.get("/api/v1/community/categories")).json()["data"] if c["slug"] == "showcase"
+    )
+    topic = await _post_topic(client, user, f"Counters {uuid.uuid4().hex[:8]}", category="showcase")
+    await client.post(f"/api/v1/community/topics/{topic['id']}/posts", json={"content": "r"}, headers=user)
+    mid = next(c for c in (await client.get("/api/v1/community/categories")).json()["data"] if c["slug"] == "showcase")
+    assert mid["topic_count"] == before["topic_count"] + 1
+    assert mid["post_count"] == before["post_count"] + 2
+
+    # delete the reply, then the topic (as its author, after clearing the reply)
+    posts = (await client.get(f"/api/v1/community/topics/{topic['id']}/posts")).json()["data"]["items"]
+    reply_id = next(p["id"] for p in posts if p["post_number"] == 2)
+    assert (await client.delete(f"/api/v1/community/posts/{reply_id}", headers=user)).status_code == 200
+    assert (await client.delete(f"/api/v1/community/topics/{topic['id']}", headers=user)).status_code == 200
+    after = next(
+        c for c in (await client.get("/api/v1/community/categories")).json()["data"] if c["slug"] == "showcase"
+    )
+    assert after["topic_count"] == before["topic_count"]
+    assert after["post_count"] == before["post_count"]


### PR DESCRIPTION
Create topic/reply under the topic row lock (concurrent replies numbered correctly — removing the lock fails the test), edit/delete own posts with counter integrity, staff-only categories, content caps, per-user rate limits. Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)