### PR TITLE
feat(community): S1.4 — likes and read tracking

### DIFF
--- a/back/app/api/v1/community.py
+++ b/back/app/api/v1/community.py
@@ -5,17 +5,32 @@ so those routes take no auth dependency at all. Writes require a session
 (CurrentUserId); ownership and staff rules live in the service.
 """
 
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from pydantic import BaseModel, Field
 
-from app.dependencies.auth import CurrentUserId
+from app.dependencies.auth import CurrentUserId, validate_access_token
 from app.dependencies.db import SessionDep
 from app.services import community_service
 
 router = APIRouter()
+
+
+async def get_optional_user_id(request: Request) -> UUID | None:
+    """The viewer if they sent a valid token, else None — public reads never
+    401: an expired session downgrades to the anonymous view."""
+    header = request.headers.get("Authorization", "")
+    if not header.startswith("Bearer "):
+        return None
+    try:
+        return await validate_access_token(header.removeprefix("Bearer ").strip())
+    except Exception:
+        return None
+
+
+OptionalUserId = Annotated[UUID | None, Depends(get_optional_user_id)]
 
 
 class TopicCreateRequest(BaseModel):
@@ -41,18 +56,22 @@ async def list_categories(db: SessionDep) -> dict[str, Any]:
 @router.get("/topics")
 async def list_topics(
     db: SessionDep,
+    viewer: OptionalUserId = None,
     category: str | None = Query(default=None, description="A category slug; omit for all."),
     top: str | None = Query(default=None, pattern="^(week|month|all)$", description="Top instead of Latest."),
     limit: int = Query(default=30, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
 ) -> dict[str, Any]:
     """Latest (default), Top (?top=week|month|all), optionally within a category
-    — where pinned topics float first."""
-    return {
-        "data": (
-            await community_service.list_topics(db, category_slug=category, top_window=top, limit=limit, offset=offset)
-        ).unwrap()
-    }
+    — where pinned topics float first. Signed-in viewers get `unread` flags."""
+    data = (
+        await community_service.list_topics(db, category_slug=category, top_window=top, limit=limit, offset=offset)
+    ).unwrap()
+    if viewer is not None and data["items"]:
+        unread = await community_service.unread_map(db, viewer, [UUID(t["id"]) for t in data["items"]])
+        for t in data["items"]:
+            t["unread"] = unread.get(t["id"], True)
+    return {"data": data}
 
 
 @router.get("/topics/{topic_id}")
@@ -64,13 +83,23 @@ async def get_topic(topic_id: UUID, db: SessionDep) -> dict[str, Any]:
 async def list_posts(
     topic_id: UUID,
     db: SessionDep,
+    viewer: OptionalUserId = None,
     after: int = Query(default=0, ge=0, description="The last post_number you have; 0 from the top."),
     limit: int = Query(default=50, ge=1, le=100),
 ) -> dict[str, Any]:
     """The thread, keyset-paginated: ask again with `after` = the last
     `post_number` received while `has_more` is true. Deleted posts are
-    placeholders — the numbering never shifts under you."""
-    return {"data": (await community_service.list_posts(db, topic_id, after=after, limit=limit)).unwrap()}
+    placeholders — the numbering never shifts under you. Signed-in viewers
+    get `liked_by_viewer` on each post."""
+    data = (await community_service.list_posts(db, topic_id, after=after, limit=limit)).unwrap()
+    if viewer is not None and data["items"]:
+        liked = await community_service.liked_post_ids(
+            db, viewer, [UUID(p["id"]) for p in data["items"] if not p["is_deleted"]]
+        )
+        for p in data["items"]:
+            if not p["is_deleted"]:
+                p["liked_by_viewer"] = p["id"] in liked
+    return {"data": data}
 
 
 @router.get("/users/{user_id}")
@@ -118,3 +147,25 @@ async def delete_post(post_id: UUID, user_id: CurrentUserId, db: SessionDep) -> 
 async def delete_topic(topic_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
     """Delete your own topic — only while nobody has replied."""
     return {"data": (await community_service.delete_topic(db, user_id, topic_id)).unwrap()}
+
+
+@router.put("/posts/{post_id}/like")
+async def like_post(post_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Like a post. Idempotent — liking twice counts once."""
+    return {"data": (await community_service.like_post(db, user_id, post_id)).unwrap()}
+
+
+@router.delete("/posts/{post_id}/like")
+async def unlike_post(post_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Take a like back. Never liked it? Still fine."""
+    return {"data": (await community_service.unlike_post(db, user_id, post_id)).unwrap()}
+
+
+class MarkReadRequest(BaseModel):
+    post_number: int = Field(ge=1, description="The highest post number now on your screen.")
+
+
+@router.put("/topics/{topic_id}/read")
+async def mark_read(topic_id: UUID, body: MarkReadRequest, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Move your read pointer — it only ever moves forward."""
+    return {"data": (await community_service.mark_read(db, user_id, topic_id, post_number=body.post_number)).unwrap()}

--- a/back/app/services/community_service.py
+++ b/back/app/services/community_service.py
@@ -473,3 +473,131 @@ async def delete_topic(
     await db.commit()
     await invalidate_categories_cache()
     return ServiceResponse.ok({"deleted": str(topic_id)})
+
+
+# ── Likes & read tracking (S1.4) ─────────────────────────────────────────────
+
+
+async def like_post(db: AsyncSession, user_id: UUID, post_id: UUID) -> ServiceResponse[dict[str, Any]]:
+    """Idempotent: the ON CONFLICT no-op means the counter bumps only when a
+    row was actually inserted — a double-click cannot double-count."""
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.models.community import CommunityPostLike
+
+    post = await db.scalar(
+        select(CommunityPost).where(CommunityPost.id == post_id, CommunityPost.is_deleted.is_(False))
+    )
+    if post is None:
+        return ServiceResponse.fail("not_found", "Post not found.")
+    result = await db.execute(
+        pg_insert(CommunityPostLike.__table__)
+        .values(post_id=post_id, user_id=user_id)
+        .on_conflict_do_nothing(index_elements=["post_id", "user_id"])
+    )
+    if result.rowcount == 1:
+        await db.execute(
+            CommunityPost.__table__.update()
+            .where(CommunityPost.id == post_id)
+            .values(like_count=CommunityPost.like_count + 1)
+        )
+    await db.commit()
+    count = await db.scalar(select(CommunityPost.like_count).where(CommunityPost.id == post_id))
+    return ServiceResponse.ok({"post_id": str(post_id), "liked": True, "like_count": int(count or 0)})
+
+
+async def unlike_post(db: AsyncSession, user_id: UUID, post_id: UUID) -> ServiceResponse[dict[str, Any]]:
+    """Unliking something never liked is a clean no-op, not an error."""
+    from sqlalchemy import delete as sa_delete
+
+    from app.models.community import CommunityPostLike
+
+    post = await db.scalar(select(CommunityPost.id).where(CommunityPost.id == post_id))
+    if post is None:
+        return ServiceResponse.fail("not_found", "Post not found.")
+    result = await db.execute(
+        sa_delete(CommunityPostLike.__table__).where(
+            CommunityPostLike.post_id == post_id, CommunityPostLike.user_id == user_id
+        )
+    )
+    if result.rowcount == 1:
+        await db.execute(
+            CommunityPost.__table__.update()
+            .where(CommunityPost.id == post_id)
+            .values(like_count=CommunityPost.like_count - 1)
+        )
+    await db.commit()
+    count = await db.scalar(select(CommunityPost.like_count).where(CommunityPost.id == post_id))
+    return ServiceResponse.ok({"post_id": str(post_id), "liked": False, "like_count": int(count or 0)})
+
+
+async def liked_post_ids(db: AsyncSession, user_id: UUID, post_ids: list[UUID]) -> set[str]:
+    """Which of these posts the viewer liked — one IN query for a whole page."""
+    from app.models.community import CommunityPostLike
+
+    if not post_ids:
+        return set()
+    rows = await db.execute(
+        select(CommunityPostLike.post_id).where(
+            CommunityPostLike.user_id == user_id, CommunityPostLike.post_id.in_(post_ids)
+        )
+    )
+    return {str(r) for r in rows.scalars()}
+
+
+async def mark_read(
+    db: AsyncSession, user_id: UUID, topic_id: UUID, *, post_number: int
+) -> ServiceResponse[dict[str, Any]]:
+    """GREATEST on conflict: an out-of-order beacon can never move the
+    pointer backward and resurrect an unread badge."""
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.models.community import CommunityTopicRead
+
+    topic = await db.scalar(
+        select(CommunityTopic.last_post_number).where(
+            CommunityTopic.id == topic_id, CommunityTopic.is_deleted.is_(False)
+        )
+    )
+    if topic is None:
+        return ServiceResponse.fail("not_found", "Topic not found.")
+    clamped = max(1, min(post_number, int(topic)))
+    stmt = pg_insert(CommunityTopicRead.__table__).values(
+        user_id=user_id, topic_id=topic_id, last_read_post_number=clamped
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["user_id", "topic_id"],
+        set_={
+            "last_read_post_number": func.greatest(
+                CommunityTopicRead.last_read_post_number, stmt.excluded.last_read_post_number
+            ),
+            "updated_at": func.now(),
+        },
+    )
+    await db.execute(stmt)
+    await db.commit()
+    return ServiceResponse.ok({"topic_id": str(topic_id), "last_read_post_number": clamped})
+
+
+async def unread_map(db: AsyncSession, user_id: UUID, topic_ids: list[UUID]) -> dict[str, bool]:
+    """topic id → has-unread, for decorating a list page in one query.
+    A topic never opened counts as unread."""
+    from app.models.community import CommunityTopicRead
+
+    if not topic_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(
+                CommunityTopic.id,
+                CommunityTopic.last_post_number,
+                CommunityTopicRead.last_read_post_number,
+            )
+            .outerjoin(
+                CommunityTopicRead,
+                (CommunityTopicRead.topic_id == CommunityTopic.id) & (CommunityTopicRead.user_id == user_id),
+            )
+            .where(CommunityTopic.id.in_(topic_ids))
+        )
+    ).all()
+    return {str(tid): (read is None or last > read) for tid, last, read in rows}

--- a/back/tests/integration/test_community.py
+++ b/back/tests/integration/test_community.py
@@ -327,3 +327,65 @@ async def test_category_counters_track_the_truth(client: AsyncClient) -> None:
     )
     assert after["topic_count"] == before["topic_count"]
     assert after["post_count"] == before["post_count"]
+
+
+# ── S1.4: likes & read tracking ──────────────────────────────────────────────
+
+
+async def test_likes_are_idempotent_and_counted(client: AsyncClient) -> None:
+    author = await _signup(client, "liked")
+    fan = await _signup(client, "fan")
+    topic = await _post_topic(client, author, f"Likes {uuid.uuid4().hex[:8]}")
+    post_id = (await client.get(f"/api/v1/community/topics/{topic['id']}/posts")).json()["data"]["items"][0]["id"]
+
+    for _ in range(3):  # hammering like stays at 1
+        liked = await client.put(f"/api/v1/community/posts/{post_id}/like", headers=fan)
+        assert liked.status_code == 200 and liked.json()["data"]["like_count"] == 1
+
+    also = await client.put(f"/api/v1/community/posts/{post_id}/like", headers=author)
+    assert also.json()["data"]["like_count"] == 2
+
+    page = (await client.get(f"/api/v1/community/topics/{topic['id']}/posts", headers=fan)).json()["data"]
+    assert page["items"][0]["liked_by_viewer"] is True and page["items"][0]["like_count"] == 2
+    anon = (await client.get(f"/api/v1/community/topics/{topic['id']}/posts")).json()["data"]
+    assert "liked_by_viewer" not in anon["items"][0], "anonymous payloads stay undecorated"
+
+    for _ in range(2):  # unlike is idempotent too
+        unliked = await client.delete(f"/api/v1/community/posts/{post_id}/like", headers=fan)
+        assert unliked.status_code == 200 and unliked.json()["data"]["like_count"] == 1
+
+    assert (await client.put(f"/api/v1/community/posts/{post_id}/like")).status_code == 401
+
+
+async def test_unread_tracking_moves_only_forward(client: AsyncClient) -> None:
+    alice = await _signup(client, "alice")
+    bob = await _signup(client, "bob")
+    topic = await _post_topic(client, bob, f"Unread {uuid.uuid4().hex[:8]}")
+
+    def flag(listing: dict, tid: str) -> bool:
+        return next(t["unread"] for t in listing["items"] if t["id"] == tid)
+
+    listing = (await client.get("/api/v1/community/topics", params={"limit": 100}, headers=alice)).json()["data"]
+    assert flag(listing, topic["id"]) is True, "never opened → unread"
+    anon = (await client.get("/api/v1/community/topics", params={"limit": 100})).json()["data"]
+    assert all("unread" not in t for t in anon["items"])
+
+    read = await client.put(f"/api/v1/community/topics/{topic['id']}/read", json={"post_number": 1}, headers=alice)
+    assert read.status_code == 200
+    listing = (await client.get("/api/v1/community/topics", params={"limit": 100}, headers=alice)).json()["data"]
+    assert flag(listing, topic["id"]) is False
+
+    # Bob replies → unread again for Alice.
+    await client.post(f"/api/v1/community/topics/{topic['id']}/posts", json={"content": "news"}, headers=bob)
+    listing = (await client.get("/api/v1/community/topics", params={"limit": 100}, headers=alice)).json()["data"]
+    assert flag(listing, topic["id"]) is True
+
+    # Alice catches up; a stale out-of-order beacon cannot drag her back.
+    await client.put(f"/api/v1/community/topics/{topic['id']}/read", json={"post_number": 2}, headers=alice)
+    await client.put(f"/api/v1/community/topics/{topic['id']}/read", json={"post_number": 1}, headers=alice)
+    listing = (await client.get("/api/v1/community/topics", params={"limit": 100}, headers=alice)).json()["data"]
+    assert flag(listing, topic["id"]) is False, "the pointer never moves backward"
+
+    # A beacon past the end clamps to the real last post.
+    clamped = await client.put(f"/api/v1/community/topics/{topic['id']}/read", json={"post_number": 999}, headers=alice)
+    assert clamped.json()["data"]["last_read_post_number"] == 2


### PR DESCRIPTION
Idempotent ON-CONFLICT likes with atomic counters, GREATEST read pointers that never move backward, viewer-decorated payloads via an optional-auth dependency (anonymous reads never 401). Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)