### PR TITLE
feat(community): S1.5 — moderation

### DIFF
--- a/back/app/api/v1/community.py
+++ b/back/app/api/v1/community.py
@@ -169,3 +169,86 @@ class MarkReadRequest(BaseModel):
 async def mark_read(topic_id: UUID, body: MarkReadRequest, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
     """Move your read pointer — it only ever moves forward."""
     return {"data": (await community_service.mark_read(db, user_id, topic_id, post_number=body.post_number)).unwrap()}
+
+
+# ── Moderation (staff) ───────────────────────────────────────────────────────
+
+
+class TopicModerateRequest(BaseModel):
+    pinned: bool | None = None
+    locked: bool | None = None
+    title: str | None = Field(default=None, max_length=300)
+    category: str | None = Field(default=None, max_length=100, description="Move to this category slug.")
+
+
+class ReportCreateRequest(BaseModel):
+    reason: str = Field(min_length=1, max_length=50)
+    detail: str = Field(default="", max_length=2000)
+
+
+@router.patch("/topics/{topic_id}")
+async def moderate_topic(
+    topic_id: UUID, body: TopicModerateRequest, user_id: CurrentUserId, db: SessionDep
+) -> dict[str, Any]:
+    """Staff: pin, lock, retitle or recategorize — any subset at once."""
+    return {
+        "data": (
+            await community_service.moderate_topic(
+                db,
+                user_id,
+                topic_id,
+                pinned=body.pinned,
+                locked=body.locked,
+                title=body.title,
+                category_slug=body.category,
+            )
+        ).unwrap()
+    }
+
+
+@router.delete("/mod/posts/{post_id}")
+async def staff_delete_post(post_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Staff: soft-delete anyone's reply (a numbered placeholder remains)."""
+    (await community_service.require_staff(db, user_id)).unwrap()
+    return {"data": (await community_service.delete_post(db, user_id, post_id, as_staff=True)).unwrap()}
+
+
+@router.delete("/mod/topics/{topic_id}")
+async def staff_delete_topic(topic_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Staff: soft-delete a whole topic, replies and all."""
+    (await community_service.require_staff(db, user_id)).unwrap()
+    return {"data": (await community_service.delete_topic(db, user_id, topic_id, as_staff=True)).unwrap()}
+
+
+@router.post("/posts/{post_id}/report", status_code=status.HTTP_201_CREATED)
+async def report_post(
+    post_id: UUID, body: ReportCreateRequest, user_id: CurrentUserId, db: SessionDep
+) -> dict[str, Any]:
+    """Flag a post for staff. Once per post per person."""
+    return {
+        "data": (
+            await community_service.report_post(db, user_id, post_id, reason=body.reason, detail=body.detail)
+        ).unwrap()
+    }
+
+
+@router.get("/mod/reports")
+async def list_reports(
+    user_id: CurrentUserId,
+    db: SessionDep,
+    report_status: str = Query(default="open", alias="status", pattern="^(open|resolved)$"),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, Any]:
+    """Staff: the report queue."""
+    return {
+        "data": (
+            await community_service.list_reports(db, user_id, status=report_status, limit=limit, offset=offset)
+        ).unwrap()
+    }
+
+
+@router.post("/mod/reports/{report_id}/resolve")
+async def resolve_report(report_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
+    """Staff: mark a report handled."""
+    return {"data": (await community_service.resolve_report(db, user_id, report_id)).unwrap()}

--- a/back/app/services/community_service.py
+++ b/back/app/services/community_service.py
@@ -601,3 +601,166 @@ async def unread_map(db: AsyncSession, user_id: UUID, topic_ids: list[UUID]) -> 
         )
     ).all()
     return {str(tid): (read is None or last > read) for tid, last, read in rows}
+
+
+# ── Moderation (S1.5) ────────────────────────────────────────────────────────
+
+
+async def require_staff(db: AsyncSession, user_id: UUID) -> ServiceResponse[User]:
+    user = await db.scalar(select(User).where(User.id == user_id, User.is_active.is_(True)))
+    if user is None or not user.is_staff:
+        return ServiceResponse.fail("forbidden", "Staff only.")
+    return ServiceResponse.ok(user)
+
+
+async def moderate_topic(
+    db: AsyncSession,
+    staff_id: UUID,
+    topic_id: UUID,
+    *,
+    pinned: bool | None = None,
+    locked: bool | None = None,
+    title: str | None = None,
+    category_slug: str | None = None,
+) -> ServiceResponse[dict[str, Any]]:
+    """Pin, lock, retitle, recategorize — any subset in one call. Moving
+    category migrates its share of both categories' counters."""
+    from app.utils.slug_utils import slugify
+
+    staff = await require_staff(db, staff_id)
+    if not staff.success:
+        return staff  # type: ignore[return-value]
+    topic = await db.scalar(
+        select(CommunityTopic)
+        .where(CommunityTopic.id == topic_id, CommunityTopic.is_deleted.is_(False))
+        .with_for_update()
+    )
+    if topic is None:
+        return ServiceResponse.fail("not_found", "Topic not found.")
+
+    if pinned is not None:
+        topic.is_pinned = pinned
+    if locked is not None:
+        topic.is_locked = locked
+    if title is not None:
+        title = title.strip()
+        if not 3 <= len(title) <= 300:
+            return ServiceResponse.fail("validation_failed", "Titles run 3 to 300 characters.")
+        topic.title = title
+        topic.slug = slugify(title)
+    if category_slug is not None:
+        cat_res = await get_category(db, category_slug)
+        if not cat_res.success:
+            return cat_res  # type: ignore[return-value]
+        new_cat = cat_res.data
+        assert new_cat is not None
+        if new_cat.id != topic.category_id:
+            live_posts = await db.scalar(
+                select(func.count())
+                .select_from(CommunityPost)
+                .where(CommunityPost.topic_id == topic.id, CommunityPost.is_deleted.is_(False))
+            )
+            await db.execute(
+                CommunityCategory.__table__.update()
+                .where(CommunityCategory.id == topic.category_id)
+                .values(
+                    topic_count=CommunityCategory.topic_count - 1,
+                    post_count=CommunityCategory.post_count - int(live_posts or 0),
+                )
+            )
+            await db.execute(
+                CommunityCategory.__table__.update()
+                .where(CommunityCategory.id == new_cat.id)
+                .values(
+                    topic_count=CommunityCategory.topic_count + 1,
+                    post_count=CommunityCategory.post_count + int(live_posts or 0),
+                )
+            )
+            topic.category_id = new_cat.id
+            await invalidate_categories_cache()
+    await db.commit()
+    return await get_topic(db, topic_id)
+
+
+async def report_post(
+    db: AsyncSession, user_id: UUID, post_id: UUID, *, reason: str, detail: str = ""
+) -> ServiceResponse[dict[str, Any]]:
+    from sqlalchemy.exc import IntegrityError
+
+    from app.models.community import CommunityReport
+
+    post = await db.scalar(
+        select(CommunityPost.id).where(CommunityPost.id == post_id, CommunityPost.is_deleted.is_(False))
+    )
+    if post is None:
+        return ServiceResponse.fail("not_found", "Post not found.")
+    reason = reason.strip()[:50]
+    if not reason:
+        return ServiceResponse.fail("validation_failed", "Say why you are reporting it.")
+    report = CommunityReport(post_id=post_id, reporter_id=user_id, reason=reason, detail=detail.strip() or None)
+    db.add(report)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        return ServiceResponse.fail("already_exists", "You already reported this post.")
+    return ServiceResponse.ok({"id": str(report.id), "post_id": str(post_id), "status": "open"})
+
+
+async def list_reports(
+    db: AsyncSession, staff_id: UUID, *, status: str = "open", limit: int = 50, offset: int = 0
+) -> ServiceResponse[dict[str, Any]]:
+    from app.models.community import CommunityReport
+
+    staff = await require_staff(db, staff_id)
+    if not staff.success:
+        return staff  # type: ignore[return-value]
+    if status not in ("open", "resolved"):
+        return ServiceResponse.fail("validation_failed", 'status is "open" or "resolved".')
+    rows = (
+        await db.execute(
+            select(CommunityReport, CommunityPost, CommunityTopic.title, User.name, func.count().over().label("total"))
+            .join(CommunityPost, CommunityPost.id == CommunityReport.post_id)
+            .join(CommunityTopic, CommunityTopic.id == CommunityPost.topic_id)
+            .outerjoin(User, User.id == CommunityReport.reporter_id)
+            .where(CommunityReport.status == status)
+            .order_by(CommunityReport.created_at.desc(), CommunityReport.id.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+    ).all()
+    items = [
+        {
+            "id": str(r.id),
+            "post_id": str(p.id),
+            "topic_id": str(p.topic_id),
+            "topic_title": topic_title,
+            "post_number": p.post_number,
+            "post_excerpt": p.content[:280],
+            "reason": r.reason,
+            "detail": r.detail,
+            "reporter": reporter_name,
+            "status": r.status,
+            "created_at": r.created_at.isoformat(),
+        }
+        for r, p, topic_title, reporter_name, _ in rows
+    ]
+    total = int(rows[0].total) if rows else 0
+    return ServiceResponse.ok({"items": items, "total": total, "limit": limit, "offset": offset})
+
+
+async def resolve_report(db: AsyncSession, staff_id: UUID, report_id: UUID) -> ServiceResponse[dict[str, Any]]:
+    from app.models.community import CommunityReport
+
+    staff = await require_staff(db, staff_id)
+    if not staff.success:
+        return staff  # type: ignore[return-value]
+    report = await db.scalar(select(CommunityReport).where(CommunityReport.id == report_id))
+    if report is None:
+        return ServiceResponse.fail("not_found", "Report not found.")
+    if report.status != "resolved":
+        report.status = "resolved"
+        report.resolved_by_id = staff_id
+        report.resolved_at = func.now()
+        await db.commit()
+    return ServiceResponse.ok({"id": str(report_id), "status": "resolved"})

--- a/back/tests/integration/test_community.py
+++ b/back/tests/integration/test_community.py
@@ -389,3 +389,105 @@ async def test_unread_tracking_moves_only_forward(client: AsyncClient) -> None:
     # A beacon past the end clamps to the real last post.
     clamped = await client.put(f"/api/v1/community/topics/{topic['id']}/read", json={"post_number": 999}, headers=alice)
     assert clamped.json()["data"]["last_read_post_number"] == 2
+
+
+# ── S1.5: moderation ─────────────────────────────────────────────────────────
+
+
+async def _make_staff(headers: dict, client: AsyncClient) -> None:
+    from sqlalchemy import update
+
+    from app.core.db import async_session_factory
+    from app.models.auth import User
+
+    me = (await client.get("/api/v1/auth/me", headers=headers)).json()["data"]
+    async with async_session_factory() as db:
+        await db.execute(update(User).where(User.id == me["id"]).values(is_staff=True))
+        await db.commit()
+
+
+async def test_moderation_is_staff_only_and_works(client: AsyncClient) -> None:
+    staff = await _signup(client, "mod")
+    await _make_staff(staff, client)
+    author = await _signup(client, "authored")
+    bystander = await _signup(client, "bystander")
+    marker = uuid.uuid4().hex[:8]
+    topic = await _post_topic(client, author, f"Mod {marker}")
+
+    # Non-staff (author included) bounce off every staff route.
+    for headers in (author, bystander):
+        assert (
+            await client.patch(f"/api/v1/community/topics/{topic['id']}", json={"pinned": True}, headers=headers)
+        ).status_code == 403
+        assert (await client.get("/api/v1/community/mod/reports", headers=headers)).status_code == 403
+        assert (await client.delete(f"/api/v1/community/mod/topics/{topic['id']}", headers=headers)).status_code == 403
+
+    # Staff pins + locks + retitles + moves in one call; counters migrate.
+    before = {
+        c["slug"]: (c["topic_count"], c["post_count"])
+        for c in (await client.get("/api/v1/community/categories")).json()["data"]
+    }
+    modded = await client.patch(
+        f"/api/v1/community/topics/{topic['id']}",
+        json={"pinned": True, "locked": True, "title": f"Pinned {marker}", "category": "bugs"},
+        headers=staff,
+    )
+    assert modded.status_code == 200, modded.text
+    body = modded.json()["data"]
+    assert body["is_pinned"] and body["is_locked"] and body["title"] == f"Pinned {marker}"
+    assert body["category_slug"] == "bugs"
+    after = {
+        c["slug"]: (c["topic_count"], c["post_count"])
+        for c in (await client.get("/api/v1/community/categories")).json()["data"]
+    }
+    assert after["help"][0] == before["help"][0] - 1 and after["bugs"][0] == before["bugs"][0] + 1
+    assert after["help"][1] == before["help"][1] - 1 and after["bugs"][1] == before["bugs"][1] + 1
+
+    # Pinned floats first on its category page.
+    listing = (await client.get("/api/v1/community/topics", params={"category": "bugs"})).json()["data"]
+    assert listing["items"][0]["id"] == topic["id"]
+
+    # Locked topic refuses replies — even from its author.
+    assert (
+        await client.post(f"/api/v1/community/topics/{topic['id']}/posts", json={"content": "x"}, headers=author)
+    ).status_code == 409
+
+    # Staff deletes the whole topic even though it is not theirs.
+    assert (await client.delete(f"/api/v1/community/mod/topics/{topic['id']}", headers=staff)).status_code == 200
+    assert (await client.get(f"/api/v1/community/topics/{topic['id']}")).status_code == 404
+
+
+async def test_report_lifecycle(client: AsyncClient) -> None:
+    staff = await _signup(client, "queue")
+    await _make_staff(staff, client)
+    author = await _signup(client, "poster")
+    reporter = await _signup(client, "reporter")
+    topic = await _post_topic(client, author, f"Report {uuid.uuid4().hex[:8]}")
+    post_id = (await client.get(f"/api/v1/community/topics/{topic['id']}/posts")).json()["data"]["items"][0]["id"]
+
+    filed = await client.post(
+        f"/api/v1/community/posts/{post_id}/report",
+        json={"reason": "spam", "detail": "so much spam"},
+        headers=reporter,
+    )
+    assert filed.status_code == 201, filed.text
+    dup = await client.post(f"/api/v1/community/posts/{post_id}/report", json={"reason": "spam"}, headers=reporter)
+    assert dup.status_code == 409 and dup.json()["error"]["code"] == "already_exists"
+
+    queue = (await client.get("/api/v1/community/mod/reports", headers=staff)).json()["data"]
+    mine = next(r for r in queue["items"] if r["post_id"] == post_id)
+    assert mine["reason"] == "spam" and mine["topic_title"].startswith("Report ")
+
+    resolved = await client.post(f"/api/v1/community/mod/reports/{mine['id']}/resolve", headers=staff)
+    assert resolved.status_code == 200
+    open_queue = (await client.get("/api/v1/community/mod/reports", headers=staff)).json()["data"]
+    assert all(r["id"] != mine["id"] for r in open_queue["items"])
+    done_queue = (
+        await client.get("/api/v1/community/mod/reports", params={"status": "resolved"}, headers=staff)
+    ).json()["data"]
+    assert any(r["id"] == mine["id"] for r in done_queue["items"])
+
+    # Staff deletes the offending post; the reporter cannot re-report a ghost.
+    assert (await client.delete(f"/api/v1/community/mod/posts/{post_id}", headers=staff)).status_code == 422
+    # (the OP is the topic — staff removes the topic instead)
+    assert (await client.delete(f"/api/v1/community/mod/topics/{topic['id']}", headers=staff)).status_code == 200


### PR DESCRIPTION
require_staff-gated pin/lock/retitle/recategorize (counters migrate), staff deletes, one-per-reporter report queue with resolve audit. Three-user permission matrix in tests. Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)