### PR TITLE
feat(community): S1.6 — search and view counting

### DIFF
--- a/back/app/api/v1/community.py
+++ b/back/app/api/v1/community.py
@@ -75,8 +75,13 @@ async def list_topics(
 
 
 @router.get("/topics/{topic_id}")
-async def get_topic(topic_id: UUID, db: SessionDep) -> dict[str, Any]:
-    return {"data": (await community_service.get_topic(db, topic_id)).unwrap()}
+async def get_topic(topic_id: UUID, db: SessionDep, request: Request, viewer: OptionalUserId = None) -> dict[str, Any]:
+    data = (await community_service.get_topic(db, topic_id)).unwrap()
+    # Count the view after the topic proved real — Redis-batched, deduped
+    # per viewer (or per address for the logged-out) for ten minutes.
+    viewer_key = str(viewer) if viewer else (request.client.host if request.client else "anon")
+    await community_service.record_view(topic_id, viewer_key)
+    return {"data": data}
 
 
 @router.get("/topics/{topic_id}/posts")
@@ -252,3 +257,19 @@ async def list_reports(
 async def resolve_report(report_id: UUID, user_id: CurrentUserId, db: SessionDep) -> dict[str, Any]:
     """Staff: mark a report handled."""
     return {"data": (await community_service.resolve_report(db, user_id, report_id)).unwrap()}
+
+
+@router.get("/search")
+async def search(
+    db: SessionDep,
+    q: str = Query(min_length=1, max_length=200),
+    category: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=50),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, Any]:
+    """Full-text search over topics and posts — websearch grammar, ranked,
+    with <mark> snippets. Title hits land at the top of the thread, body
+    hits carry their post_number."""
+    return {
+        "data": (await community_service.search(db, q=q, category_slug=category, limit=limit, offset=offset)).unwrap()
+    }

--- a/back/app/core/celery.py
+++ b/back/app/core/celery.py
@@ -10,7 +10,7 @@ celery_app = Celery(
     "nodum",
     broker=settings.CELERY_BROKER_URL,
     backend=settings.CELERY_RESULT_BACKEND,
-    include=["app.tasks.vault_io", "app.tasks.maintenance"],
+    include=["app.tasks.vault_io", "app.tasks.maintenance", "app.tasks.community"],
 )
 
 celery_app.conf.update(
@@ -27,6 +27,10 @@ celery_app.conf.update(
         "prune-sessions-nightly": {
             "task": "tasks.prune_sessions",
             "schedule": 24 * 60 * 60.0,
+        },
+        "flush-community-views": {
+            "task": "tasks.flush_community_views",
+            "schedule": 60.0,
         },
     },
 )

--- a/back/app/services/community_service.py
+++ b/back/app/services/community_service.py
@@ -11,7 +11,7 @@ thousands of posts deep and OFFSET degrades linearly.
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.auth import User
@@ -764,3 +764,128 @@ async def resolve_report(db: AsyncSession, staff_id: UUID, report_id: UUID) -> S
         report.resolved_at = func.now()
         await db.commit()
     return ServiceResponse.ok({"id": str(report_id), "status": "resolved"})
+
+
+# ── Search & views (S1.6) ────────────────────────────────────────────────────
+
+VIEWS_HASH_KEY = "community:views"
+_VIEW_DEDUPE_TTL_SECONDS = 600
+
+
+async def search(
+    db: AsyncSession, *, q: str, category_slug: str | None = None, limit: int = 20, offset: int = 0
+) -> ServiceResponse[dict[str, Any]]:
+    """Full-text over topic titles and post bodies, merged and ranked.
+
+    Title hits point at the top of the thread (post 1); body hits carry the
+    post_number so the client can land mid-thread. Same websearch grammar,
+    ranking and <mark> snippets as the vault search."""
+    q = q.strip()
+    if not q:
+        return ServiceResponse.fail("validation_failed", "Search for something.")
+    tsquery = func.websearch_to_tsquery("english", q)
+    headline_opts = "StartSel=<mark>, StopSel=</mark>, MaxWords=30, MinWords=10, MaxFragments=2"
+
+    title_sel = select(
+        CommunityTopic.id.label("topic_id"),
+        CommunityTopic.title.label("topic_title"),
+        CommunityTopic.slug.label("topic_slug"),
+        literal(1).label("post_number"),
+        func.ts_headline("english", CommunityTopic.title, tsquery, headline_opts).label("snippet"),
+        func.ts_rank_cd(CommunityTopic.title_tsv, tsquery).label("rank"),
+    ).where(CommunityTopic.title_tsv.op("@@")(tsquery), CommunityTopic.is_deleted.is_(False))
+    post_sel = (
+        select(
+            CommunityPost.topic_id.label("topic_id"),
+            CommunityTopic.title.label("topic_title"),
+            CommunityTopic.slug.label("topic_slug"),
+            CommunityPost.post_number.label("post_number"),
+            func.ts_headline("english", CommunityPost.content, tsquery, headline_opts).label("snippet"),
+            func.ts_rank_cd(CommunityPost.content_tsv, tsquery).label("rank"),
+        )
+        .join(CommunityTopic, CommunityTopic.id == CommunityPost.topic_id)
+        .where(
+            CommunityPost.content_tsv.op("@@")(tsquery),
+            CommunityPost.is_deleted.is_(False),
+            CommunityTopic.is_deleted.is_(False),
+        )
+    )
+    if category_slug is not None:
+        cat_res = await get_category(db, category_slug)
+        if not cat_res.success:
+            return cat_res  # type: ignore[return-value]
+        assert cat_res.data is not None
+        title_sel = title_sel.where(CommunityTopic.category_id == cat_res.data.id)
+        post_sel = post_sel.where(CommunityTopic.category_id == cat_res.data.id)
+
+    union = title_sel.union_all(post_sel).subquery()
+    stmt = (
+        select(union, func.count().over().label("total"))
+        .order_by(union.c.rank.desc(), union.c.topic_id.desc(), union.c.post_number)
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = (await db.execute(stmt)).all()
+    items = [
+        {
+            "topic_id": str(r.topic_id),
+            "topic_title": r.topic_title,
+            "topic_slug": r.topic_slug,
+            "post_number": int(r.post_number),
+            "snippet": r.snippet,
+            "rank": float(r.rank or 0),
+        }
+        for r in rows
+    ]
+    total = int(rows[0].total) if rows else 0
+    return ServiceResponse.ok({"query": q, "items": items, "total": total, "limit": limit, "offset": offset})
+
+
+async def record_view(topic_id: UUID, viewer_key: str) -> None:
+    """Count a topic view without touching Postgres: SETNX dedupes one
+    viewer for ten minutes, HINCRBY batches the rest for the beat flusher.
+    Redis down → the view is simply not counted (never a 500)."""
+    try:
+        from app.core.redis import redis_control
+
+        dedupe = f"community:viewdedupe:{topic_id}:{viewer_key}"
+        if await redis_control.set(dedupe, "1", ex=_VIEW_DEDUPE_TTL_SECONDS, nx=True):
+            await redis_control.hincrby(VIEWS_HASH_KEY, str(topic_id), 1)
+    except Exception:
+        pass
+
+
+async def flush_views() -> int:
+    """Drain the pending-views hash into view_count (the beat task's body).
+    Rename-then-read: increments landing mid-flush go to a fresh hash."""
+    from app.core.redis import redis_control
+
+    tmp = f"{VIEWS_HASH_KEY}:flush"
+    try:
+        if not await redis_control.exists(VIEWS_HASH_KEY):
+            return 0
+        await redis_control.rename(VIEWS_HASH_KEY, tmp)
+        pending = await redis_control.hgetall(tmp)
+    except Exception:
+        return 0
+    if not pending:
+        return 0
+    from app.core.db import async_session_factory
+
+    flushed = 0
+    async with async_session_factory() as db:
+        for topic_id, count in pending.items():
+            tid = topic_id.decode() if isinstance(topic_id, bytes) else topic_id
+            n = int(count)
+            await db.execute(
+                CommunityTopic.__table__.update()
+                .where(CommunityTopic.id == UUID(tid))
+                .values(view_count=CommunityTopic.view_count + n)
+            )
+            flushed += n
+        await db.commit()
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        await redis_control.delete(tmp)
+    return flushed

--- a/back/app/tasks/community.py
+++ b/back/app/tasks/community.py
@@ -1,0 +1,20 @@
+"""Community periodic jobs (Celery beat)."""
+
+import asyncio
+
+from app.core.celery import celery_app
+from app.core.logging import get_logger
+
+logger = get_logger("community_tasks")
+
+
+@celery_app.task(name="tasks.flush_community_views")
+def flush_community_views() -> int:
+    """Drain Redis-batched topic views into view_count once a minute —
+    a view is a counter tick, never a per-request Postgres write."""
+    from app.services.community_service import flush_views
+
+    flushed = asyncio.run(flush_views())
+    if flushed:
+        logger.info("community_views_flushed", count=flushed)
+    return flushed

--- a/back/tests/integration/test_community.py
+++ b/back/tests/integration/test_community.py
@@ -491,3 +491,62 @@ async def test_report_lifecycle(client: AsyncClient) -> None:
     assert (await client.delete(f"/api/v1/community/mod/posts/{post_id}", headers=staff)).status_code == 422
     # (the OP is the topic — staff removes the topic instead)
     assert (await client.delete(f"/api/v1/community/mod/topics/{topic['id']}", headers=staff)).status_code == 200
+
+
+# ── S1.6: search & views ─────────────────────────────────────────────────────
+
+
+async def test_search_finds_titles_and_bodies_with_snippets(client: AsyncClient) -> None:
+    user = await _signup(client, "searcher")
+    marker = f"xylophone{uuid.uuid4().hex[:6]}"
+    topic = await _post_topic(client, user, f"The {marker} question")
+    await client.post(
+        f"/api/v1/community/topics/{topic['id']}/posts",
+        json={"content": f"Deep in the thread the {marker} answer hides."},
+        headers=user,
+    )
+    other = await _post_topic(client, user, f"Unrelated {uuid.uuid4().hex[:6]}")
+
+    hits = (await client.get("/api/v1/community/search", params={"q": marker})).json()["data"]
+    # Three honest hits: the title, the OP body ("OP for <title>"), the reply.
+    assert hits["total"] == 3, hits
+    numbers = sorted(h["post_number"] for h in hits["items"])
+    assert numbers == [1, 1, 2], "a title hit and two body hits"
+    assert all("<mark>" in h["snippet"] for h in hits["items"])
+    assert all(h["topic_id"] == topic["id"] for h in hits["items"])
+
+    scoped = (await client.get("/api/v1/community/search", params={"q": marker, "category": "bugs"})).json()["data"]
+    assert scoped["total"] == 0, "category filter applies"
+
+    # Deleted content leaves the index view.
+    assert (await client.delete(f"/api/v1/community/topics/{other['id']}", headers=user)).status_code == 200
+    empty = (await client.get("/api/v1/community/search", params={"q": "Unrelated"})).json()["data"]
+    assert all(h["topic_id"] != other["id"] for h in empty["items"])
+
+    blank = await client.get("/api/v1/community/search", params={"q": " "})
+    assert blank.status_code == 422
+
+
+async def test_views_batch_in_redis_and_flush_to_the_row(client: AsyncClient) -> None:
+    from app.core.redis import redis_control
+    from app.services.community_service import VIEWS_HASH_KEY, flush_views
+
+    user = await _signup(client, "viewer")
+    topic = await _post_topic(client, user, f"Views {uuid.uuid4().hex[:8]}")
+
+    await redis_control.delete(VIEWS_HASH_KEY)
+    # Two GETs from the same viewer inside the dedupe window count once.
+    assert (await client.get(f"/api/v1/community/topics/{topic['id']}", headers=user)).status_code == 200
+    assert (await client.get(f"/api/v1/community/topics/{topic['id']}", headers=user)).status_code == 200
+    # A different (anonymous) viewer counts separately.
+    assert (await client.get(f"/api/v1/community/topics/{topic['id']}")).status_code == 200
+
+    pending = await redis_control.hgetall(VIEWS_HASH_KEY)
+    ours = {k.decode() if isinstance(k, bytes) else k: int(v) for k, v in pending.items()}
+    assert ours.get(topic["id"]) == 2, ours
+
+    flushed = await flush_views()
+    assert flushed >= 2
+    refreshed = (await client.get(f"/api/v1/community/topics/{topic['id']}", headers=user)).json()["data"]
+    assert refreshed["view_count"] == 2
+    assert not await redis_control.exists(VIEWS_HASH_KEY), "the hash drained"


### PR DESCRIPTION
Merged FTS over titles+bodies with <mark> snippets and honest pagination; Redis-batched view counting drained by a 60s Celery beat task, all fail-open. Closes the backend sprint. Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)