### PR TITLE
feat(community): S2.1 — public forum pages

### DIFF
--- a/web/e2e/community.spec.ts
+++ b/web/e2e/community.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { signupFreshUser } from "./helpers";
+
+/** The community forum's public read surface: anonymous browsing, the
+ *  crawler view, and — load-bearing — that a stranger's markdown renders
+ *  inert: raw HTML as literal text, images as links, no script execution. */
+
+async function apiCall(page: Page, method: string, url: string, body?: unknown) {
+  return page.evaluate(
+    async ({ method, url, body }) => {
+      const token = (await (await fetch("/api/v1/auth/refresh", { method: "POST" })).json()).data.access_token;
+      const r = await fetch(`/api/v1${url}`, {
+        method,
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+      const text = await r.text();
+      if (!r.ok) throw new Error(`${method} ${url} → ${r.status}: ${text.slice(0, 200)}`);
+      return text ? JSON.parse(text).data : null;
+    },
+    { method, url, body },
+  );
+}
+
+test.describe("community", () => {
+  test("anonymous browse, crawler view, and hostile markdown stays inert", async ({ page, request, context }) => {
+    test.setTimeout(90_000);
+    await signupFreshUser(page, "forum");
+    const marker = `e2e${Date.now().toString(36)}`;
+    const hostile = [
+      `A post by ${marker}.`,
+      "",
+      "<script>window.__pwned = true</script>",
+      "",
+      "![tracking pixel](https://evil.example/pixel.png)",
+      "",
+      "[innocent looking](javascript:window.__pwned2=true)",
+      "",
+      "```",
+      "code stays code",
+      "```",
+    ].join("\n");
+    const topic = (await apiCall(page, "POST", "/community/topics", {
+      category: "showcase",
+      title: `Showcase ${marker}`,
+      content: hostile,
+    })) as { id: string; slug: string };
+    await apiCall(page, "POST", `/community/topics/${topic.id}/posts`, { content: `Reply from ${marker}.` });
+
+    // Anonymous from here on. The thread page renders fresh (never cached
+    // before now); the list pages are allowed 30s of staleness by design.
+    await context.clearCookies();
+    await page.goto(`/community/t/${topic.id}/${topic.slug}`);
+    await expect(page.getByRole("heading", { name: `Showcase ${marker}` })).toBeVisible();
+
+    // The hostile bits render as text/links, never as behavior.
+    await expect(page.getByText(`A post by ${marker}.`)).toBeVisible();
+    await expect(page.getByText("<script>window.__pwned = true</script>")).toBeVisible();
+    expect(await page.evaluate(() => (window as { __pwned?: boolean }).__pwned)).toBeUndefined();
+    const pixel = page.getByRole("link", { name: "tracking pixel" });
+    await expect(pixel).toBeVisible();
+    expect(await page.locator("article img").count()).toBe(0);
+    const badHref = await page.getByRole("link", { name: "innocent looking" }).getAttribute("href");
+    expect(badHref ?? "").not.toContain("javascript:");
+    await expect(page.getByText("code stays code")).toBeVisible();
+    await expect(page.getByText(`Reply from ${marker}.`)).toBeVisible();
+
+    // The crawler view: content, title and canonical in the raw HTML.
+    const raw = await (await request.get(`/community/t/${topic.id}/${topic.slug}`)).text();
+    expect(raw).toContain(`A post by ${marker}.`);
+    expect(raw).toContain(`<title>Showcase ${marker}`);
+    expect(raw).toContain(`/community/t/${topic.id}/${topic.slug}`);
+    expect(raw).not.toContain("noindex");
+
+    // Wrong slug 308s to canonical.
+    const redirected = await request.get(`/community/t/${topic.id}/nonsense`, { maxRedirects: 0 });
+    expect(redirected.status()).toBe(308);
+
+    // The list pages catch up within their 30s revalidate window.
+    await expect(async () => {
+      await page.goto("/community/c/showcase");
+      await expect(page.getByRole("link", { name: `Showcase ${marker}` })).toBeVisible({ timeout: 1500 });
+    }).toPass({ timeout: 45_000 });
+    await page.goto("/community");
+    await expect(page.getByRole("heading", { name: "Talk Nodum" })).toBeVisible();
+  });
+});

--- a/web/src/app/(marketing)/community/c/[slug]/page.tsx
+++ b/web/src/app/(marketing)/community/c/[slug]/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { getCategories, getTopics } from "@/lib/api/community-server";
+
+import { Pager, TopicRow } from "../../topic-row";
+
+const PAGE_SIZE = 30;
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  const category = (await getCategories())?.find((c) => c.slug === slug);
+  if (!category) return {};
+  return {
+    title: `${category.name} · Nodum Community`,
+    description: category.description ?? `${category.name} — the Nodum community.`,
+  };
+}
+
+export default async function CategoryPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const { slug } = await params;
+  const page = Math.max(1, Number((await searchParams).page) || 1);
+  const [categories, topics] = await Promise.all([
+    getCategories(),
+    getTopics({ category: slug, limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE }),
+  ]);
+  const category = categories?.find((c) => c.slug === slug);
+  if (!category || !topics) notFound();
+
+  return (
+    <section>
+      <p className="mb-1">
+        <Link href="/community" className="mk-navlink px-0">
+          ← All categories
+        </Link>
+      </p>
+      <h2 className="mk-display text-[1.5rem]">{category.name}</h2>
+      {category.description && <p className="mb-4 opacity-70">{category.description}</p>}
+      {topics.items.length > 0 ? (
+        <>
+          <ul>
+            {topics.items.map((t) => (
+              <TopicRow key={t.id} topic={t} showCategory={false} />
+            ))}
+          </ul>
+          <Pager
+            base={`/community/c/${slug}`}
+            page={page}
+            hasPrev={page > 1}
+            hasNext={page * PAGE_SIZE < topics.total}
+          />
+        </>
+      ) : (
+        <p className="mk-card px-4 py-6 opacity-70">No topics here yet.</p>
+      )}
+    </section>
+  );
+}

--- a/web/src/app/(marketing)/community/layout.tsx
+++ b/web/src/app/(marketing)/community/layout.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { SiteFooter, SiteNav } from "@/components/marketing/site-chrome";
+
+export const metadata: Metadata = {
+  title: "Community · Nodum",
+  description: "The Nodum community — announcements, help, bug reports, feature requests and showcases.",
+};
+
+/** The community shell: site chrome plus the forum's own little nav.
+ *  Public and server-rendered — a person (or crawler) reads it without an
+ *  account; signing in lights up composing, likes and unread chips. */
+export default function CommunityLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SiteNav />
+      <div className="mx-auto w-full max-w-5xl px-4 pt-10 pb-16 sm:px-6">
+        <header className="mb-8 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="mk-eyebrow">Community</p>
+            <h1 className="mk-display text-[1.9rem] sm:text-[2.2rem]">
+              <Link href="/community">Talk Nodum</Link>
+            </h1>
+          </div>
+          <nav className="flex items-center gap-2" aria-label="Community sections">
+            <Link className="mk-navlink" href="/community">
+              Latest
+            </Link>
+            <Link className="mk-navlink" href="/community?top=week">
+              Top
+            </Link>
+            <Link className="mk-btn mk-btn--primary h-9 px-4 text-[0.875rem]" href="/community/new">
+              New topic
+            </Link>
+          </nav>
+        </header>
+        {children}
+      </div>
+      <SiteFooter />
+    </>
+  );
+}

--- a/web/src/app/(marketing)/community/page.tsx
+++ b/web/src/app/(marketing)/community/page.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+
+import { getCategories, getTopics } from "@/lib/api/community-server";
+
+import { Pager, TopicRow } from "./topic-row";
+
+const PAGE_SIZE = 30;
+
+/** The forum's front page: the category rail and Latest (or Top) topics. */
+export default async function CommunityIndex({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string; top?: string }>;
+}) {
+  const params = await searchParams;
+  const page = Math.max(1, Number(params.page) || 1);
+  const top = params.top && ["week", "month", "all"].includes(params.top) ? params.top : undefined;
+  const [categories, topics] = await Promise.all([
+    getCategories(),
+    getTopics({ top, limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE }),
+  ]);
+
+  return (
+    <div className="grid gap-10 md:grid-cols-[240px_1fr]">
+      <aside aria-label="Categories">
+        <h2 className="mk-eyebrow mb-3">Categories</h2>
+        <ul className="space-y-2">
+          {(categories ?? []).map((c) => (
+            <li key={c.id}>
+              <Link href={`/community/c/${c.slug}`} className="mk-card block px-3 py-2 hover:opacity-90">
+                <span className="font-medium">{c.name}</span>
+                <span className="ml-2 text-[0.78rem] tabular-nums opacity-60">{c.topic_count}</span>
+                {c.description && <p className="mt-0.5 text-[0.8rem] opacity-60">{c.description}</p>}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <section aria-label={top ? "Top topics" : "Latest topics"}>
+        <h2 className="mk-eyebrow mb-1">{top ? `Top · ${top}` : "Latest"}</h2>
+        {topics && topics.items.length > 0 ? (
+          <>
+            <ul>
+              {topics.items.map((t) => (
+                <TopicRow key={t.id} topic={t} />
+              ))}
+            </ul>
+            <Pager
+              base={top ? `/community?top=${top}` : "/community"}
+              page={page}
+              hasPrev={page > 1}
+              hasNext={page * PAGE_SIZE < topics.total}
+            />
+          </>
+        ) : (
+          <p className="mk-card px-4 py-6 opacity-70">
+            Nothing here yet — <Link href="/community/new" className="underline">start the first topic</Link>.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/(marketing)/community/t/[id]/[[...slug]]/page.tsx
+++ b/web/src/app/(marketing)/community/t/[id]/[[...slug]]/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, permanentRedirect } from "next/navigation";
+
+import { PostBody } from "@/components/community/post-body";
+import { getPosts, getTopic } from "@/lib/api/community-server";
+
+import { Pager } from "../../../topic-row";
+
+const PAGE_SIZE = 50;
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params;
+  const topic = await getTopic(id);
+  if (!topic) return {};
+  return {
+    title: `${topic.title} · Nodum Community`,
+    description: `${topic.reply_count} replies in ${topic.category_slug ?? "the community"}.`,
+    alternates: { canonical: `/community/t/${topic.id}/${topic.slug}` },
+  };
+}
+
+/** A thread. URLs are id-first; a wrong or missing slug 308s to canonical. */
+export default async function TopicPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string; slug?: string[] }>;
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const { id, slug } = await params;
+  const page = Math.max(1, Number((await searchParams).page) || 1);
+  const topic = await getTopic(id);
+  if (!topic) notFound();
+  if ((slug?.[0] ?? "") !== topic.slug) {
+    permanentRedirect(`/community/t/${topic.id}/${topic.slug}${page > 1 ? `?page=${page}` : ""}`);
+  }
+  const posts = await getPosts(topic.id, (page - 1) * PAGE_SIZE, PAGE_SIZE);
+  if (!posts) notFound();
+
+  return (
+    <article>
+      <p className="mb-1">
+        {topic.category_slug && (
+          <Link href={`/community/c/${topic.category_slug}`} className="mk-navlink px-0">
+            ← {topic.category_slug}
+          </Link>
+        )}
+      </p>
+      <h2 className="mk-display text-[1.6rem]">
+        {topic.is_pinned && <span className="mk-eyebrow mr-2">Pinned</span>}
+        {topic.is_locked && <span className="mk-eyebrow mr-2">Locked</span>}
+        {topic.title}
+      </h2>
+      <p className="mb-6 text-[0.85rem] opacity-60">
+        {topic.author ? (
+          <Link href={`/community/u/${topic.author.id}`} className="hover:underline">
+            {topic.author.name}
+          </Link>
+        ) : (
+          "deleted user"
+        )}
+        {" · "}
+        {new Date(topic.created_at).toLocaleDateString()} · {topic.reply_count} replies · {topic.view_count} views
+      </p>
+
+      <ol className="space-y-6">
+        {posts.items.map((post) => (
+          <li key={post.id} id={`post-${post.post_number}`} className="mk-card px-4 py-3">
+            {post.is_deleted ? (
+              <p className="text-[0.85rem] italic opacity-50">#{post.post_number} — removed</p>
+            ) : (
+              <>
+                <p className="mb-2 text-[0.8rem] opacity-60">
+                  {post.author ? (
+                    <Link href={`/community/u/${post.author.id}`} className="font-medium hover:underline">
+                      {post.author.name}
+                    </Link>
+                  ) : (
+                    "deleted user"
+                  )}
+                  {" · "}
+                  <a href={`#post-${post.post_number}`} className="tabular-nums hover:underline">
+                    #{post.post_number}
+                  </a>
+                  {" · "}
+                  {post.created_at && new Date(post.created_at).toLocaleDateString()}
+                  {post.edited_at && <em> · edited</em>}
+                  {typeof post.like_count === "number" && post.like_count > 0 && <> · ♥ {post.like_count}</>}
+                </p>
+                <PostBody content={post.content ?? ""} />
+              </>
+            )}
+          </li>
+        ))}
+      </ol>
+      <Pager
+        base={`/community/t/${topic.id}/${topic.slug}`}
+        page={page}
+        hasPrev={page > 1}
+        hasNext={posts.has_more}
+      />
+      {topic.is_locked && <p className="mt-6 opacity-60">This topic is locked — no new replies.</p>}
+    </article>
+  );
+}

--- a/web/src/app/(marketing)/community/topic-row.tsx
+++ b/web/src/app/(marketing)/community/topic-row.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+import type { CommunityTopicItem } from "@/lib/api/community-server";
+
+/** One topic line — shared by the index, category and profile pages. */
+export function TopicRow({ topic, showCategory = true }: { topic: CommunityTopicItem; showCategory?: boolean }) {
+  const when = new Date(topic.last_post_at).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return (
+    <li className="flex items-baseline gap-3 border-b border-white/5 py-3 last:border-b-0">
+      <div className="min-w-0 flex-1">
+        <Link
+          href={`/community/t/${topic.id}/${topic.slug}`}
+          className="text-[1rem] font-medium hover:underline"
+        >
+          {topic.is_pinned && <span className="mk-eyebrow mr-2">Pinned</span>}
+          {topic.is_locked && <span className="mk-eyebrow mr-2">Locked</span>}
+          {topic.title}
+        </Link>
+        <p className="mt-0.5 text-[0.8rem] opacity-60">
+          {topic.author ? topic.author.name : "deleted user"}
+          {showCategory && topic.category_slug ? (
+            <>
+              {" · "}
+              <Link href={`/community/c/${topic.category_slug}`} className="hover:underline">
+                {topic.category_slug}
+              </Link>
+            </>
+          ) : null}
+        </p>
+      </div>
+      <span className="shrink-0 text-[0.8rem] tabular-nums opacity-60" title="Replies">
+        {topic.reply_count} ↩
+      </span>
+      <span className="shrink-0 text-[0.8rem] tabular-nums opacity-60" title="Views">
+        {topic.view_count} 👁
+      </span>
+      <span className="shrink-0 text-[0.8rem] tabular-nums opacity-60">{when}</span>
+    </li>
+  );
+}
+
+export function Pager({
+  base,
+  page,
+  hasPrev,
+  hasNext,
+}: {
+  base: string;
+  page: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+}) {
+  if (!hasPrev && !hasNext) return null;
+  const sep = base.includes("?") ? "&" : "?";
+  return (
+    <nav className="mt-6 flex items-center justify-between" aria-label="Pages">
+      {hasPrev ? (
+        <a className="mk-navlink" href={`${base}${sep}page=${page - 1}`}>
+          ← Newer
+        </a>
+      ) : (
+        <span />
+      )}
+      {hasNext ? (
+        <a className="mk-navlink" href={`${base}${sep}page=${page + 1}`}>
+          Older →
+        </a>
+      ) : (
+        <span />
+      )}
+    </nav>
+  );
+}

--- a/web/src/app/(marketing)/community/u/[id]/page.tsx
+++ b/web/src/app/(marketing)/community/u/[id]/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { getProfile } from "@/lib/api/community-server";
+
+import { TopicRow } from "../../topic-row";
+
+export const metadata: Metadata = { robots: { index: false } };
+
+/** A member's public forum profile. noindex — people pages are for people. */
+export default async function ProfilePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const profile = await getProfile(id);
+  if (!profile) notFound();
+
+  return (
+    <section>
+      <h2 className="mk-display text-[1.6rem]">
+        {profile.name}
+        {profile.is_staff && <span className="mk-eyebrow ml-3">Staff</span>}
+      </h2>
+      <p className="mb-6 text-[0.85rem] opacity-60">
+        Joined {new Date(profile.joined_at).toLocaleDateString()} · {profile.topic_count} topics ·{" "}
+        {profile.post_count} posts
+      </p>
+      <h3 className="mk-eyebrow mb-2">Recent topics</h3>
+      {profile.recent_topics.length > 0 ? (
+        <ul>
+          {profile.recent_topics.map((t) => (
+            <TopicRow key={t.id} topic={t} />
+          ))}
+        </ul>
+      ) : (
+        <p className="mk-card px-4 py-6 opacity-70">No topics yet.</p>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/community/post-body.tsx
+++ b/web/src/components/community/post-body.tsx
@@ -1,0 +1,45 @@
+/**
+ * Render one forum post's markdown — the first place strangers' markdown is
+ * shown to other users, so the pipeline is deliberately narrow:
+ *
+ * - GFM only, no rehype-raw: raw HTML (a literal `<script>`) renders as the
+ *   TEXT the author typed, exactly what react-markdown does by default.
+ * - react-markdown's defaultUrlTransform stays in force (javascript: etc.
+ *   never survive into href).
+ * - Images become links: a remote <img> is a tracking pixel / IP leak aimed
+ *   at every reader, so the reader clicks through instead.
+ * - External links open in a new tab with rel guards.
+ *
+ * Server component — posts render into the initial HTML for crawlers.
+ */
+
+import Link from "next/link";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function PostBody({ content }: { content: string }) {
+  return (
+    <div className="mk-prose">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          img: ({ src, alt }) => (
+            <a href={typeof src === "string" ? src : undefined} target="_blank" rel="noreferrer noopener nofollow">
+              {alt || "image"}
+            </a>
+          ),
+          a: ({ href, children }) =>
+            href?.startsWith("/") ? (
+              <Link href={href}>{children}</Link>
+            ) : (
+              <a href={href} target="_blank" rel="noreferrer noopener nofollow">
+                {children}
+              </a>
+            ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/web/src/components/marketing/site-chrome.tsx
+++ b/web/src/components/marketing/site-chrome.tsx
@@ -26,6 +26,9 @@ export function SiteNav() {
           <Link className="mk-navlink" href="/learn">
             Learn
           </Link>
+          <Link className="mk-navlink" href="/community">
+            Community
+          </Link>
           <Link className="mk-navlink" href="/docs">
             Docs
           </Link>

--- a/web/src/lib/api/community-server.ts
+++ b/web/src/lib/api/community-server.ts
@@ -1,0 +1,119 @@
+/**
+ * Server-side reads of the public community endpoints.
+ *
+ * Same construction as public-server.ts (see its rationale): straight to the
+ * API origin, envelope unwrapped, null on any failure so pages render their
+ * own empty states. One difference — `revalidate: 30` instead of `no-store`:
+ * forum pages are read far more often than they change, nothing here is a
+ * privacy action, and thirty seconds of staleness is what every Discourse
+ * front page already lives with.
+ *
+ * Server-only by construction — no "use client" file may import it, and the
+ * endpoints need no credentials, so nothing here can leak a session.
+ */
+
+const API_ORIGIN = (process.env.API_PROXY_URL ?? "http://localhost:8000").replace(/\/+$/, "");
+
+export interface CommunityAuthor {
+  id: string;
+  name: string;
+  avatar_url: string | null;
+}
+
+export interface CommunityCategory {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  position: number;
+  is_staff_only_posting: boolean;
+  topic_count: number;
+  post_count: number;
+}
+
+export interface CommunityTopicItem {
+  id: string;
+  category_id: string;
+  category_slug?: string;
+  title: string;
+  slug: string;
+  author: CommunityAuthor | null;
+  is_pinned: boolean;
+  is_locked: boolean;
+  reply_count: number;
+  last_post_number: number;
+  view_count: number;
+  created_at: string;
+  last_post_at: string;
+}
+
+export interface CommunityTopicList {
+  items: CommunityTopicItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface CommunityPostItem {
+  id: string;
+  post_number: number;
+  is_deleted: boolean;
+  author?: CommunityAuthor | null;
+  content?: string;
+  like_count?: number;
+  edited_at?: string | null;
+  created_at?: string;
+}
+
+export interface CommunityPostPage {
+  items: CommunityPostItem[];
+  has_more: boolean;
+  limit: number;
+  after: number;
+}
+
+export interface CommunityProfile {
+  id: string;
+  name: string;
+  avatar_url: string | null;
+  is_staff: boolean;
+  joined_at: string;
+  topic_count: number;
+  post_count: number;
+  recent_topics: CommunityTopicItem[];
+}
+
+async function getCommunity<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${API_ORIGIN}/api/v1/community${path}`, {
+      headers: { Accept: "application/json" },
+      next: { revalidate: 30 },
+    });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    if (body && typeof body === "object" && "data" in body) {
+      return (body as { data: T }).data;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export const getCategories = () => getCommunity<CommunityCategory[]>("/categories");
+
+export const getTopics = (params: { category?: string; top?: string; limit?: number; offset?: number }) => {
+  const q = new URLSearchParams();
+  if (params.category) q.set("category", params.category);
+  if (params.top) q.set("top", params.top);
+  if (params.limit) q.set("limit", String(params.limit));
+  if (params.offset) q.set("offset", String(params.offset));
+  return getCommunity<CommunityTopicList>(`/topics?${q}`);
+};
+
+export const getTopic = (id: string) => getCommunity<CommunityTopicItem>(`/topics/${id}`);
+
+export const getPosts = (topicId: string, after = 0, limit = 50) =>
+  getCommunity<CommunityPostPage>(`/topics/${topicId}/posts?after=${after}&limit=${limit}`);
+
+export const getProfile = (userId: string) => getCommunity<CommunityProfile>(`/users/${userId}`);


### PR DESCRIPTION
/community server-rendered on the marketing chrome: index, categories, id-first threads (wrong slug 308s), noindex profiles. Untrusted markdown provably inert (raw HTML as text, images as links). e2e covers the crawler view and hostile-markdown safety. Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)