### PR TITLE
feat(community): S2.2 — composing from the page

### DIFF
--- a/web/e2e/community.spec.ts
+++ b/web/e2e/community.spec.ts
@@ -85,4 +85,52 @@ test.describe("community", () => {
     await page.goto("/community");
     await expect(page.getByRole("heading", { name: "Talk Nodum" })).toBeVisible();
   });
+
+
+  test("signed-in users compose, reply, edit and delete through the UI", async ({ page, browser }) => {
+    test.setTimeout(90_000);
+    await signupFreshUser(page, "composer");
+    const marker = `ui${Date.now().toString(36)}`;
+
+    // Compose a topic through the form, preview first.
+    await page.goto("/community/new");
+    await page.getByLabel("Category").selectOption("help");
+    await page.getByLabel("Title").fill(`Composed ${marker}`);
+    await page.getByLabel("Markdown").fill(`**Bold** words from ${marker}.`);
+    await page.getByRole("button", { name: "preview" }).click();
+    await expect(page.locator(".mk-prose strong", { hasText: "Bold" })).toBeVisible();
+    await page.getByRole("button", { name: "write" }).click();
+    await page.getByRole("button", { name: "Create topic" }).click();
+    await expect(page).toHaveURL(/\/community\/t\//, { timeout: 15_000 });
+    await expect(page.getByRole("heading", { name: `Composed ${marker}` })).toBeVisible();
+    await expect(page.locator("article strong", { hasText: "Bold" })).toBeVisible();
+
+    // Reply, refresh-free.
+    await page.getByLabel("Markdown").fill(`A reply from ${marker}.`);
+    await page.getByRole("button", { name: "Post reply" }).click();
+    await expect(page.getByText(`A reply from ${marker}.`)).toBeVisible({ timeout: 15_000 });
+
+    // Edit the reply; the edited marker appears.
+    const replyCard = page.locator("li", { hasText: `A reply from ${marker}.` }).last();
+    await replyCard.getByRole("button", { name: "Edit" }).click();
+    await replyCard.getByLabel("Markdown").fill(`A better reply from ${marker}.`);
+    await replyCard.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText(`A better reply from ${marker}.`)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("edited")).toBeVisible();
+
+    // A second user sees no controls on someone else's post.
+    const other = await browser.newContext();
+    const otherPage = await other.newPage();
+    await signupFreshUser(otherPage, "bystander");
+    await otherPage.goto(page.url());
+    await expect(otherPage.getByText(`A better reply from ${marker}.`)).toBeVisible();
+    await expect(otherPage.getByRole("button", { name: "Edit" })).toHaveCount(0);
+    await other.close();
+
+    // Delete the reply — a placeholder remains.
+    page.on("dialog", (d) => void d.accept());
+    await page.locator("li", { hasText: `A better reply from ${marker}.` }).last()
+      .getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByText("#2 — removed")).toBeVisible({ timeout: 15_000 });
+  });
 });

--- a/web/src/app/(marketing)/community/new/new-topic-form.tsx
+++ b/web/src/app/(marketing)/community/new/new-topic-form.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { MarkdownBox } from "@/components/community/markdown-box";
+import { communityApi } from "@/lib/api/endpoints";
+import { useAuthStore } from "@/lib/stores/auth-store";
+
+export function NewTopicForm({
+  categories,
+}: {
+  categories: { slug: string; name: string; staffOnly: boolean }[];
+}) {
+  const status = useAuthStore((s) => s.status);
+  const user = useAuthStore((s) => s.user);
+  const router = useRouter();
+  const [category, setCategory] = useState("help");
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (status === "anonymous") {
+    return (
+      <p className="mk-card px-4 py-6">
+        <Link href="/login" className="underline">
+          Log in
+        </Link>{" "}
+        to start a topic — reading needs no account, writing does.
+      </p>
+    );
+  }
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const topic = await communityApi.createTopic(category, title, content);
+      router.push(`/community/t/${topic.id}/${topic.slug}`);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create the topic.");
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form
+      className="mx-auto max-w-2xl space-y-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!busy) void submit();
+      }}
+    >
+      <h2 className="mk-display text-[1.5rem]">New topic</h2>
+      <label className="block text-[0.85rem]">
+        <span className="mk-eyebrow mb-1 block">Category</span>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          className="mk-card w-full px-3 py-2"
+          aria-label="Category"
+        >
+          {categories.map((c) => (
+            <option key={c.slug} value={c.slug} disabled={c.staffOnly && !user?.is_staff}>
+              {c.name}
+              {c.staffOnly ? " (staff)" : ""}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="block text-[0.85rem]">
+        <span className="mk-eyebrow mb-1 block">Title</span>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Say it in one clear line"
+          className="mk-card w-full px-3 py-2"
+          aria-label="Title"
+        />
+      </label>
+      <MarkdownBox value={content} onChange={setContent} placeholder="What's on your mind? Markdown works." />
+      {error && <p className="text-[0.85rem] text-red-400">{error}</p>}
+      <button
+        type="submit"
+        disabled={busy || title.trim().length < 3 || !content.trim()}
+        className="mk-btn mk-btn--primary h-10 px-5 disabled:opacity-50"
+      >
+        {busy ? "Creating…" : "Create topic"}
+      </button>
+    </form>
+  );
+}

--- a/web/src/app/(marketing)/community/new/page.tsx
+++ b/web/src/app/(marketing)/community/new/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { getCategories } from "@/lib/api/community-server";
+
+import { NewTopicForm } from "./new-topic-form";
+
+export const metadata: Metadata = { title: "New topic · Nodum Community", robots: { index: false } };
+
+export default async function NewTopicPage() {
+  const categories = (await getCategories()) ?? [];
+  return <NewTopicForm categories={categories.map((c) => ({ slug: c.slug, name: c.name, staffOnly: c.is_staff_only_posting }))} />;
+}

--- a/web/src/app/(marketing)/community/t/[id]/[[...slug]]/page.tsx
+++ b/web/src/app/(marketing)/community/t/[id]/[[...slug]]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
 
 import { PostBody } from "@/components/community/post-body";
+import { PostControls, ReplyBox } from "@/components/community/thread-actions";
 import { getPosts, getTopic } from "@/lib/api/community-server";
 
 import { Pager } from "../../../topic-row";
@@ -89,6 +90,14 @@ export default async function TopicPage({
                   {typeof post.like_count === "number" && post.like_count > 0 && <> · ♥ {post.like_count}</>}
                 </p>
                 <PostBody content={post.content ?? ""} />
+                <PostControls
+                  postId={post.id}
+                  postNumber={post.post_number}
+                  authorId={post.author?.id ?? null}
+                  topicId={topic.id}
+                  content={post.content ?? ""}
+                  locked={topic.is_locked}
+                />
               </>
             )}
           </li>
@@ -101,6 +110,7 @@ export default async function TopicPage({
         hasNext={posts.has_more}
       />
       {topic.is_locked && <p className="mt-6 opacity-60">This topic is locked — no new replies.</p>}
+      {!posts.has_more && <ReplyBox topicId={topic.id} locked={topic.is_locked} />}
     </article>
   );
 }

--- a/web/src/components/community/markdown-box.tsx
+++ b/web/src/components/community/markdown-box.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/** The forum's composer input: a textarea with Write | Preview tabs. The
+ *  preview runs the same narrow pipeline as the rendered post, so what you
+ *  see is byte-for-byte what readers get. */
+
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function MarkdownBox({
+  value,
+  onChange,
+  placeholder,
+  minRows = 6,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  minRows?: number;
+}) {
+  const [tab, setTab] = useState<"write" | "preview">("write");
+  return (
+    <div className="mk-card overflow-hidden">
+      <div className="flex gap-1 border-b border-white/10 px-2 pt-2">
+        {(["write", "preview"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className={`rounded-t px-3 py-1.5 text-[0.8rem] capitalize ${
+              tab === t ? "bg-white/10 font-medium" : "opacity-60 hover:opacity-90"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      {tab === "write" ? (
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          rows={minRows}
+          className="w-full resize-y bg-transparent px-3 py-2 font-mono text-[0.9rem] outline-none"
+          aria-label="Markdown"
+        />
+      ) : (
+        <div className="mk-prose min-h-24 px-3 py-2">
+          {value.trim() ? (
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                img: ({ src, alt }) => (
+                  <a href={typeof src === "string" ? src : undefined}>{alt || "image"}</a>
+                ),
+              }}
+            >
+              {value}
+            </ReactMarkdown>
+          ) : (
+            <p className="opacity-50">Nothing to preview yet.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/community/thread-actions.tsx
+++ b/web/src/components/community/thread-actions.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+/** The signed-in layer of a thread page: the reply box, and edit/delete on
+ *  your own posts. Server-rendered content stays untouched — these islands
+ *  sit beside it and `router.refresh()` after every mutation so the page
+ *  re-renders from the source of truth. */
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { MarkdownBox } from "@/components/community/markdown-box";
+import { communityApi } from "@/lib/api/endpoints";
+import { useAuthStore } from "@/lib/stores/auth-store";
+
+export function ReplyBox({ topicId, locked }: { topicId: string; locked: boolean }) {
+  const status = useAuthStore((s) => s.status);
+  const router = useRouter();
+  const [content, setContent] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (locked) return null;
+  if (status !== "authenticated") {
+    return (
+      <p className="mk-card mt-8 px-4 py-4">
+        <Link href="/login" className="underline">
+          Log in
+        </Link>{" "}
+        to reply — reading needs no account, writing does.
+      </p>
+    );
+  }
+  return (
+    <div className="mt-8 space-y-3">
+      <h3 className="mk-eyebrow">Reply</h3>
+      <MarkdownBox value={content} onChange={setContent} placeholder="Add to the conversation. Markdown works." minRows={4} />
+      {error && <p className="text-[0.85rem] text-red-400">{error}</p>}
+      <button
+        type="button"
+        disabled={busy || !content.trim()}
+        onClick={async () => {
+          setBusy(true);
+          setError(null);
+          try {
+            await communityApi.reply(topicId, content);
+            setContent("");
+            router.refresh();
+          } catch (e) {
+            setError(e instanceof Error ? e.message : "Could not post the reply.");
+          } finally {
+            setBusy(false);
+          }
+        }}
+        className="mk-btn mk-btn--primary h-10 px-5 disabled:opacity-50"
+      >
+        {busy ? "Posting…" : "Post reply"}
+      </button>
+    </div>
+  );
+}
+
+export function PostControls({
+  postId,
+  postNumber,
+  authorId,
+  topicId,
+  content,
+  locked,
+}: {
+  postId: string;
+  postNumber: number;
+  authorId: string | null;
+  topicId: string;
+  content: string;
+  locked: boolean;
+}) {
+  const user = useAuthStore((s) => s.user);
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(content);
+  const [busy, setBusy] = useState(false);
+
+  if (!user || user.id !== authorId || locked) return null;
+
+  if (editing) {
+    return (
+      <div className="mt-3 space-y-2">
+        <MarkdownBox value={draft} onChange={setDraft} minRows={4} />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={busy || !draft.trim()}
+            className="mk-btn mk-btn--primary h-8 px-3 text-[0.8rem] disabled:opacity-50"
+            onClick={async () => {
+              setBusy(true);
+              try {
+                await communityApi.editPost(postId, draft);
+                setEditing(false);
+                router.refresh();
+              } finally {
+                setBusy(false);
+              }
+            }}
+          >
+            Save
+          </button>
+          <button type="button" className="mk-navlink text-[0.8rem]" onClick={() => setEditing(false)}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <p className="mt-2 flex gap-3 text-[0.78rem] opacity-70">
+      <button type="button" className="hover:underline" onClick={() => setEditing(true)}>
+        Edit
+      </button>
+      <button
+        type="button"
+        className="hover:underline"
+        onClick={async () => {
+          if (!window.confirm(postNumber === 1 ? "Delete this topic?" : "Delete this reply?")) return;
+          if (postNumber === 1) {
+            await communityApi.deleteTopic(topicId).catch(() => undefined);
+            window.location.href = "/community";
+            return;
+          }
+          await communityApi.deletePost(postId).catch(() => undefined);
+          router.refresh();
+        }}
+      >
+        Delete
+      </button>
+    </p>
+  );
+}

--- a/web/src/lib/api/community-server.ts
+++ b/web/src/lib/api/community-server.ts
@@ -83,11 +83,13 @@ export interface CommunityProfile {
   recent_topics: CommunityTopicItem[];
 }
 
-async function getCommunity<T>(path: string): Promise<T | null> {
+async function getCommunity<T>(path: string, fresh = false): Promise<T | null> {
   try {
     const res = await fetch(`${API_ORIGIN}/api/v1/community${path}`, {
       headers: { Accept: "application/json" },
-      next: { revalidate: 30 },
+      // Lists tolerate 30s of staleness; a thread you just replied to must
+      // show the reply on the very next render.
+      ...(fresh ? { cache: "no-store" as const } : { next: { revalidate: 30 } }),
     });
     if (!res.ok) return null;
     const body: unknown = await res.json();
@@ -111,9 +113,9 @@ export const getTopics = (params: { category?: string; top?: string; limit?: num
   return getCommunity<CommunityTopicList>(`/topics?${q}`);
 };
 
-export const getTopic = (id: string) => getCommunity<CommunityTopicItem>(`/topics/${id}`);
+export const getTopic = (id: string) => getCommunity<CommunityTopicItem>(`/topics/${id}`, true);
 
 export const getPosts = (topicId: string, after = 0, limit = 50) =>
-  getCommunity<CommunityPostPage>(`/topics/${topicId}/posts?after=${after}&limit=${limit}`);
+  getCommunity<CommunityPostPage>(`/topics/${topicId}/posts?after=${after}&limit=${limit}`, true);
 
 export const getProfile = (userId: string) => getCommunity<CommunityProfile>(`/users/${userId}`);

--- a/web/src/lib/api/endpoints.ts
+++ b/web/src/lib/api/endpoints.ts
@@ -372,6 +372,19 @@ export const mcpApi = {
 
 // ── API keys (the public REST API's credential) ──────────────────────────────
 
+// ── Community ────────────────────────────────────────────────────────────────
+
+export const communityApi = {
+  createTopic: (category: string, title: string, content: string) =>
+    apiJson<{ id: string; slug: string }>("/community/topics", "POST", { category, title, content }),
+  reply: (topicId: string, content: string) =>
+    apiJson<{ id: string; post_number: number }>(`/community/topics/${topicId}/posts`, "POST", { content }),
+  editPost: (postId: string, content: string) =>
+    apiJson<{ id: string }>(`/community/posts/${postId}`, "PATCH", { content }),
+  deletePost: (postId: string) => apiJson<{ deleted: string }>(`/community/posts/${postId}`, "DELETE"),
+  deleteTopic: (topicId: string) => apiJson<{ deleted: string }>(`/community/topics/${topicId}`, "DELETE"),
+};
+
 export const apiKeysApi = {
   list: () => api<ApiKeyList>("/api-keys"),
   /** The key is in THIS response only — show it once. */

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -6,6 +6,8 @@ export interface User {
   name: string;
   avatar_url: string | null;
   email_verified: boolean;
+  /** Community moderation rights (pin/lock/delete, staff-only categories). */
+  is_staff?: boolean;
   settings: Record<string, unknown>;
   created_at: string;
 }


### PR DESCRIPTION
/community/new composer with a Write|Preview textarea (the preview IS the renderer), reply/edit/delete islands beside the server-rendered thread, thread fetches no-store so a fresh reply is on the next render. e2e drives the whole lifecycle plus a cross-user controls check. Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)