### PR TITLE
feat(community): S2.3 — likes, unread chips, search

### DIFF
--- a/web/e2e/community.spec.ts
+++ b/web/e2e/community.spec.ts
@@ -133,4 +133,55 @@ test.describe("community", () => {
       .getByRole("button", { name: "Delete" }).click();
     await expect(page.getByText("#2 — removed")).toBeVisible({ timeout: 15_000 });
   });
+
+  test("likes, unread chips and search work for signed-in members", async ({ page, browser }) => {
+    test.setTimeout(120_000);
+    await signupFreshUser(page, "alice");
+    const marker = `eng${Date.now().toString(36)}`;
+    const topic = (await apiCall(page, "POST", "/community/topics", {
+      category: "help",
+      title: `Engage ${marker}`,
+      content: `Original ${marker} content with quokkas.`,
+    })) as { id: string; slug: string };
+
+    // Alice opens the thread — the beacon marks it read; she likes the OP.
+    await page.goto(`/community/t/${topic.id}/${topic.slug}`);
+    const like = page.getByRole("button", { name: "Like" });
+    await expect(like).toBeVisible();
+    await like.click();
+    await expect(page.getByRole("button", { name: "Unlike" })).toHaveText("♥ 1");
+    await page.reload();
+    await expect(page.getByRole("button", { name: "Unlike" })).toHaveText("♥ 1", { timeout: 10_000 });
+
+    // Bob replies from his own session.
+    const bobCtx = await browser.newContext();
+    const bob = await bobCtx.newPage();
+    await signupFreshUser(bob, "bob");
+    await apiCall(bob, "POST", `/community/topics/${topic.id}/posts`, { content: `Bob answers ${marker}.` });
+    await bobCtx.close();
+
+    // Alice's list shows the unread chip; opening the thread clears it.
+    await expect(async () => {
+      await page.goto("/community?limit=100");
+      const row = page.locator("li", { hasText: `Engage ${marker}` }).first();
+      await expect(row.getByTestId("unread-badge")).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 45_000 });
+    await page.goto(`/community/t/${topic.id}/${topic.slug}`);
+    await expect(page.getByText(`Bob answers ${marker}.`)).toBeVisible();
+    await page.goto("/community?limit=100");
+    const row = page.locator("li", { hasText: `Engage ${marker}` }).first();
+    await expect(row).toBeVisible();
+    await expect(row.getByTestId("unread-badge")).toHaveCount(0);
+
+    // Search finds title and body, snippet marked; body hit deep-links.
+    await page.goto("/community/search");
+    await page.getByLabel("Search the community").fill("quokkas");
+    await expect(page.locator("mark").first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("link", { name: new RegExp(`Engage ${marker}`) }).first()).toBeVisible();
+
+    // The profile page shows Alice's topic.
+    const me = (await apiCall(page, "GET", "/auth/me")) as { id: string };
+    await page.goto(`/community/u/${me.id}`);
+    await expect(page.getByRole("link", { name: `Engage ${marker}` })).toBeVisible();
+  });
 });

--- a/web/src/app/(marketing)/community/c/[slug]/page.tsx
+++ b/web/src/app/(marketing)/community/c/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { ListEngagement } from "@/components/community/engagement";
 import { getCategories, getTopics } from "@/lib/api/community-server";
 
 import { Pager, TopicRow } from "../../topic-row";
@@ -45,11 +46,13 @@ export default async function CategoryPage({
       {category.description && <p className="mb-4 opacity-70">{category.description}</p>}
       {topics.items.length > 0 ? (
         <>
-          <ul>
-            {topics.items.map((t) => (
-              <TopicRow key={t.id} topic={t} showCategory={false} />
-            ))}
-          </ul>
+          <ListEngagement query={`category=${slug}&limit=${PAGE_SIZE}&offset=${(page - 1) * PAGE_SIZE}`}>
+            <ul>
+              {topics.items.map((t) => (
+                <TopicRow key={t.id} topic={t} showCategory={false} />
+              ))}
+            </ul>
+          </ListEngagement>
           <Pager
             base={`/community/c/${slug}`}
             page={page}

--- a/web/src/app/(marketing)/community/layout.tsx
+++ b/web/src/app/(marketing)/community/layout.tsx
@@ -30,6 +30,9 @@ export default function CommunityLayout({ children }: { children: React.ReactNod
             <Link className="mk-navlink" href="/community?top=week">
               Top
             </Link>
+            <Link className="mk-navlink" href="/community/search">
+              Search
+            </Link>
             <Link className="mk-btn mk-btn--primary h-9 px-4 text-[0.875rem]" href="/community/new">
               New topic
             </Link>

--- a/web/src/app/(marketing)/community/page.tsx
+++ b/web/src/app/(marketing)/community/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { ListEngagement } from "@/components/community/engagement";
+
 import { getCategories, getTopics } from "@/lib/api/community-server";
 
 import { Pager, TopicRow } from "./topic-row";
@@ -40,11 +42,13 @@ export default async function CommunityIndex({
         <h2 className="mk-eyebrow mb-1">{top ? `Top · ${top}` : "Latest"}</h2>
         {topics && topics.items.length > 0 ? (
           <>
-            <ul>
-              {topics.items.map((t) => (
-                <TopicRow key={t.id} topic={t} />
-              ))}
-            </ul>
+            <ListEngagement query={`${top ? `top=${top}&` : ""}limit=${PAGE_SIZE}&offset=${(page - 1) * PAGE_SIZE}`}>
+              <ul>
+                {topics.items.map((t) => (
+                  <TopicRow key={t.id} topic={t} />
+                ))}
+              </ul>
+            </ListEngagement>
             <Pager
               base={top ? `/community?top=${top}` : "/community"}
               page={page}

--- a/web/src/app/(marketing)/community/search/page.tsx
+++ b/web/src/app/(marketing)/community/search/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+import { SearchClient } from "./search-client";
+
+export const metadata: Metadata = { title: "Search · Nodum Community", robots: { index: false } };
+
+export default function CommunitySearchPage() {
+  return <SearchClient />;
+}

--- a/web/src/app/(marketing)/community/search/search-client.tsx
+++ b/web/src/app/(marketing)/community/search/search-client.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { api } from "@/lib/api/client";
+
+interface Hit {
+  topic_id: string;
+  topic_title: string;
+  topic_slug: string;
+  post_number: number;
+  snippet: string;
+}
+
+/** ts_headline snippets carry real <mark> tags around matches and nothing
+ *  else trustworthy — escape everything, then re-admit only the literal
+ *  mark tags (the search-pane recipe). */
+function sanitizeSnippet(snippet: string): string {
+  const escaped = snippet.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+  return escaped.replaceAll("&lt;mark&gt;", "<mark>").replaceAll("&lt;/mark&gt;", "</mark>");
+}
+
+export function SearchClient() {
+  const [q, setQ] = useState("");
+  const [hits, setHits] = useState<Hit[] | null>(null);
+  const [total, setTotal] = useState(0);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    // All state changes happen inside the debounce tick — never synchronously
+    // in the effect body (cascading-render lint, and it is just as correct).
+    const query = q.trim();
+    const t = setTimeout(() => {
+      if (query.length < 2) {
+        setHits(null);
+        setBusy(false);
+        return;
+      }
+      setBusy(true);
+      void api<{ items: Hit[]; total: number }>(`/community/search?q=${encodeURIComponent(query)}&limit=25`)
+        .then((data) => {
+          setHits(data.items);
+          setTotal(data.total);
+        })
+        .catch(() => setHits([]))
+        .finally(() => setBusy(false));
+    }, 250);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  return (
+    <section className="mx-auto max-w-2xl">
+      <h2 className="mk-display mb-4 text-[1.5rem]">Search the community</h2>
+      <input
+        autoFocus
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        placeholder="Words, phrases, -exclusions…"
+        aria-label="Search the community"
+        className="mk-card w-full px-4 py-3"
+      />
+      {busy && <p className="mt-4 opacity-60">Searching…</p>}
+      {hits !== null && !busy && (
+        <>
+          <p className="mt-4 text-[0.85rem] opacity-60">
+            {total} result{total === 1 ? "" : "s"}
+          </p>
+          <ul className="mt-2 space-y-4">
+            {hits.map((h) => (
+              <li key={`${h.topic_id}-${h.post_number}`} className="mk-card px-4 py-3">
+                <Link
+                  href={`/community/t/${h.topic_id}/${h.topic_slug}${h.post_number > 1 ? `#post-${h.post_number}` : ""}`}
+                  className="font-medium hover:underline"
+                >
+                  {h.topic_title}
+                  {h.post_number > 1 && <span className="ml-2 text-[0.8rem] opacity-60">#{h.post_number}</span>}
+                </Link>
+                <p
+                  className="mt-1 text-[0.85rem] opacity-80 [&_mark]:rounded-sm [&_mark]:bg-[var(--mk-accent,#7c6cf6)]/30 [&_mark]:px-0.5 [&_mark]:text-inherit"
+                  dangerouslySetInnerHTML={{ __html: sanitizeSnippet(h.snippet) }}
+                />
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/src/app/(marketing)/community/t/[id]/[[...slug]]/page.tsx
+++ b/web/src/app/(marketing)/community/t/[id]/[[...slug]]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
 
+import { LikeButton, ThreadEngagement } from "@/components/community/engagement";
 import { PostBody } from "@/components/community/post-body";
 import { PostControls, ReplyBox } from "@/components/community/thread-actions";
 import { getPosts, getTopic } from "@/lib/api/community-server";
@@ -65,6 +66,7 @@ export default async function TopicPage({
         {new Date(topic.created_at).toLocaleDateString()} · {topic.reply_count} replies · {topic.view_count} views
       </p>
 
+      <ThreadEngagement topicId={topic.id} maxPostNumber={posts.items.length ? posts.items[posts.items.length - 1].post_number : 1}>
       <ol className="space-y-6">
         {posts.items.map((post) => (
           <li key={post.id} id={`post-${post.post_number}`} className="mk-card px-4 py-3">
@@ -87,7 +89,8 @@ export default async function TopicPage({
                   {" · "}
                   {post.created_at && new Date(post.created_at).toLocaleDateString()}
                   {post.edited_at && <em> · edited</em>}
-                  {typeof post.like_count === "number" && post.like_count > 0 && <> · ♥ {post.like_count}</>}
+                  {" · "}
+                  <LikeButton postId={post.id} initialCount={post.like_count ?? 0} />
                 </p>
                 <PostBody content={post.content ?? ""} />
                 <PostControls
@@ -103,6 +106,7 @@ export default async function TopicPage({
           </li>
         ))}
       </ol>
+      </ThreadEngagement>
       <Pager
         base={`/community/t/${topic.id}/${topic.slug}`}
         page={page}

--- a/web/src/app/(marketing)/community/topic-row.tsx
+++ b/web/src/app/(marketing)/community/topic-row.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { UnreadBadge } from "@/components/community/engagement";
+
 import type { CommunityTopicItem } from "@/lib/api/community-server";
 
 /** One topic line — shared by the index, category and profile pages. */
@@ -16,6 +18,7 @@ export function TopicRow({ topic, showCategory = true }: { topic: CommunityTopic
           {topic.is_locked && <span className="mk-eyebrow mr-2">Locked</span>}
           {topic.title}
         </Link>
+        <UnreadBadge topicId={topic.id} />
         <p className="mt-0.5 text-[0.8rem] opacity-60">
           {topic.author ? topic.author.name : "deleted user"}
           {showCategory && topic.category_slug ? (

--- a/web/src/components/community/engagement.tsx
+++ b/web/src/components/community/engagement.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+/**
+ * The signed-in decoration layer for community pages, as one context per
+ * page: a provider fetches the viewer-decorated payload ONCE (never one
+ * request per row) and small leaf components consume it beside the
+ * server-rendered content. Anonymous viewers cost zero extra requests.
+ */
+
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+
+import { api, apiJson } from "@/lib/api/client";
+import { useAuthStore } from "@/lib/stores/auth-store";
+
+// ── Thread: likes + the read beacon ──────────────────────────────────────────
+
+interface ThreadViewerState {
+  liked: Set<string>;
+  toggle: (postId: string) => Promise<{ like_count: number; liked: boolean } | null>;
+}
+
+const ThreadContext = createContext<ThreadViewerState | null>(null);
+
+export function ThreadEngagement({
+  topicId,
+  maxPostNumber,
+  children,
+}: {
+  topicId: string;
+  maxPostNumber: number;
+  children: React.ReactNode;
+}) {
+  const status = useAuthStore((s) => s.status);
+  const [liked, setLiked] = useState<Set<string>>(new Set());
+  const beaconSent = useRef(false);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    // One decorated fetch for the whole page's liked-state…
+    void api<{ items: { id: string; liked_by_viewer?: boolean; is_deleted: boolean }[] }>(
+      `/community/topics/${topicId}/posts?after=${Math.max(0, maxPostNumber - 50)}&limit=50`,
+    )
+      .then((page) =>
+        setLiked(new Set(page.items.filter((p) => !p.is_deleted && p.liked_by_viewer).map((p) => p.id))),
+      )
+      .catch(() => undefined);
+    // …and one read beacon for the furthest post on screen.
+    if (!beaconSent.current) {
+      beaconSent.current = true;
+      void apiJson(`/community/topics/${topicId}/read`, "PUT", { post_number: maxPostNumber }).catch(
+        () => undefined,
+      );
+    }
+  }, [status, topicId, maxPostNumber]);
+
+  const toggle = async (postId: string) => {
+    if (status !== "authenticated") return null;
+    const isLiked = liked.has(postId);
+    try {
+      const out = await apiJson<{ like_count: number; liked: boolean }>(
+        `/community/posts/${postId}/like`,
+        isLiked ? "DELETE" : "PUT",
+      );
+      setLiked((prev) => {
+        const next = new Set(prev);
+        if (out.liked) next.add(postId);
+        else next.delete(postId);
+        return next;
+      });
+      return out;
+    } catch {
+      return null;
+    }
+  };
+
+  return <ThreadContext.Provider value={{ liked, toggle }}>{children}</ThreadContext.Provider>;
+}
+
+export function LikeButton({ postId, initialCount }: { postId: string; initialCount: number }) {
+  const status = useAuthStore((s) => s.status);
+  const thread = useContext(ThreadContext);
+  const [count, setCount] = useState(initialCount);
+  if (status !== "authenticated" || !thread) {
+    return initialCount > 0 ? <span className="text-[0.78rem] opacity-60">♥ {initialCount}</span> : null;
+  }
+  const isLiked = thread.liked.has(postId);
+  return (
+    <button
+      type="button"
+      aria-label={isLiked ? "Unlike" : "Like"}
+      aria-pressed={isLiked}
+      className={`text-[0.78rem] ${isLiked ? "text-red-400" : "opacity-60 hover:opacity-100"}`}
+      onClick={async () => {
+        const out = await thread.toggle(postId);
+        if (out) setCount(out.like_count);
+      }}
+    >
+      ♥ {count}
+    </button>
+  );
+}
+
+// ── Lists: unread chips ──────────────────────────────────────────────────────
+
+const UnreadContext = createContext<Map<string, boolean> | null>(null);
+
+export function ListEngagement({
+  query,
+  children,
+}: {
+  /** The same query string the server used, so the decorated fetch matches. */
+  query: string;
+  children: React.ReactNode;
+}) {
+  const status = useAuthStore((s) => s.status);
+  const [unread, setUnread] = useState<Map<string, boolean> | null>(null);
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    void api<{ items: { id: string; unread?: boolean }[] }>(`/community/topics?${query}`)
+      .then((data) => setUnread(new Map(data.items.map((t) => [t.id, Boolean(t.unread)]))))
+      .catch(() => undefined);
+  }, [status, query]);
+  return <UnreadContext.Provider value={unread}>{children}</UnreadContext.Provider>;
+}
+
+export function UnreadBadge({ topicId }: { topicId: string }) {
+  const unread = useContext(UnreadContext);
+  if (!unread?.get(topicId)) return null;
+  return (
+    <span
+      className="ml-2 inline-block size-2 rounded-full bg-[var(--mk-accent,#7c6cf6)] align-middle"
+      title="New since you last read"
+      data-testid="unread-badge"
+    />
+  );
+}

--- a/web/src/components/community/thread-actions.tsx
+++ b/web/src/components/community/thread-actions.tsx
@@ -124,7 +124,8 @@ export function PostControls({
           if (!window.confirm(postNumber === 1 ? "Delete this topic?" : "Delete this reply?")) return;
           if (postNumber === 1) {
             await communityApi.deleteTopic(topicId).catch(() => undefined);
-            window.location.href = "/community";
+            router.push("/community");
+            router.refresh();
             return;
           }
           await communityApi.deletePost(postId).catch(() => undefined);


### PR DESCRIPTION
One decorated fetch per page (never per row): like buttons with optimistic counts, unread dots, the read beacon, and debounced FTS search with sanitized <mark> snippets. Two-user unread cycle in e2e. Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)