### PR TITLE
feat(community): S2.4 — reporting and the staff surface

### DIFF
--- a/web/e2e/community.spec.ts
+++ b/web/e2e/community.spec.ts
@@ -1,6 +1,16 @@
+import { execSync } from "node:child_process";
+
 import { expect, test, type Page } from "@playwright/test";
 
 import { signupFreshUser } from "./helpers";
+
+/** Staff is a column with no UI by design — operators flip it with SQL (or
+ *  the bootstrap env). The test does exactly what an operator does. */
+function makeStaff(email: string) {
+  execSync(
+    `docker exec nodum-postgres psql -U nodum -d nodum -c "UPDATE users SET is_staff=true WHERE email='${email}'"`,
+  );
+}
 
 /** The community forum's public read surface: anonymous browsing, the
  *  crawler view, and — load-bearing — that a stranger's markdown renders
@@ -183,5 +193,61 @@ test.describe("community", () => {
     const me = (await apiCall(page, "GET", "/auth/me")) as { id: string };
     await page.goto(`/community/u/${me.id}`);
     await expect(page.getByRole("link", { name: `Engage ${marker}` })).toBeVisible();
+  });
+
+  test("reporting and staff moderation work end to end", async ({ page, browser }) => {
+    test.setTimeout(120_000);
+    const marker = `mod${Date.now().toString(36)}`;
+
+    // An ordinary member posts something…
+    await signupFreshUser(page, "citizen");
+    const topic = (await apiCall(page, "POST", "/community/topics", {
+      category: "help",
+      title: `Moderate ${marker}`,
+      content: `Questionable ${marker} content.`,
+    })) as { id: string; slug: string };
+
+    // …a second member reports it from the page…
+    const reporterCtx = await browser.newContext();
+    const reporter = await reporterCtx.newPage();
+    await signupFreshUser(reporter, "reporter");
+    await reporter.goto(`/community/t/${topic.id}/${topic.slug}`);
+    await reporter.getByRole("button", { name: "Report" }).click();
+    await reporter.getByLabel("Reason").selectOption("spam");
+    await reporter.getByLabel("Report detail").fill("very spammy");
+    await reporter.getByRole("button", { name: "Send" }).click();
+    await expect(reporter.getByText("Reported — staff will look.")).toBeVisible();
+    await reporterCtx.close();
+
+    // …and staff handles it.
+    const staffCtx = await browser.newContext();
+    const staff = await staffCtx.newPage();
+    const staffEmail = await signupFreshUser(staff, "sheriff");
+    makeStaff(staffEmail);
+    await staff.reload(); // re-bootstraps the session with is_staff on the payload
+
+    // The queue shows the report; resolve clears it.
+    await staff.goto("/community/mod");
+    const row = staff.locator('[data-testid="report-row"]', { hasText: `Moderate ${marker}` });
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    await expect(row.getByText("very spammy")).toBeVisible();
+    await row.getByRole("button", { name: "Resolve" }).click();
+    await expect(row).toHaveCount(0, { timeout: 10_000 });
+
+    // Staff controls on the thread: pin + lock, then the lock hides replies.
+    await staff.goto(`/community/t/${topic.id}/${topic.slug}`);
+    const controls = staff.getByTestId("staff-controls");
+    await expect(controls).toBeVisible();
+    await controls.getByRole("button", { name: "Pin", exact: true }).click();
+    await expect(controls.getByRole("button", { name: "Unpin" })).toBeVisible({ timeout: 10_000 });
+    await controls.getByRole("button", { name: "Lock", exact: true }).click();
+    await expect(staff.getByText("This topic is locked")).toBeVisible({ timeout: 10_000 });
+    await staffCtx.close();
+
+    // The ordinary member now finds no reply box, and never sees staff UI.
+    await page.goto(`/community/t/${topic.id}/${topic.slug}`);
+    await expect(page.getByText("This topic is locked")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Post reply" })).toHaveCount(0);
+    await expect(page.getByTestId("staff-controls")).toHaveCount(0);
   });
 });

--- a/web/src/app/(marketing)/community/mod/page.tsx
+++ b/web/src/app/(marketing)/community/mod/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+import { ReportsQueue } from "./reports-queue";
+
+export const metadata: Metadata = { title: "Reports · Nodum Community", robots: { index: false } };
+
+export default function ModPage() {
+  return <ReportsQueue />;
+}

--- a/web/src/app/(marketing)/community/mod/reports-queue.tsx
+++ b/web/src/app/(marketing)/community/mod/reports-queue.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/** The staff report queue. The server refuses non-staff with 403 — this page
+ *  just mirrors that politely for anyone who wanders in. */
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { communityApi } from "@/lib/api/endpoints";
+import type { CommunityReportItem } from "@/lib/api/types";
+import { useAuthStore } from "@/lib/stores/auth-store";
+
+export function ReportsQueue() {
+  const status = useAuthStore((s) => s.status);
+  const user = useAuthStore((s) => s.user);
+  const [tab, setTab] = useState<"open" | "resolved">("open");
+  const [items, setItems] = useState<CommunityReportItem[] | null>(null);
+
+  const load = useCallback(() => {
+    void communityApi
+      .listReports(tab)
+      .then((data) => setItems(data.items))
+      .catch(() => setItems([]));
+  }, [tab]);
+
+  useEffect(() => {
+    if (status === "authenticated" && user?.is_staff) load();
+  }, [status, user?.is_staff, load]);
+
+  if (status === "loading") return <p className="opacity-60">Loading…</p>;
+  if (!user?.is_staff) {
+    return <p className="mk-card px-4 py-6 opacity-70">Staff only. Nothing to see here — honestly.</p>;
+  }
+
+  return (
+    <section className="mx-auto max-w-3xl">
+      <h2 className="mk-display mb-4 text-[1.5rem]">Reports</h2>
+      <div className="mb-4 flex gap-2">
+        {(["open", "resolved"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => {
+              setTab(t);
+              setItems(null);
+            }}
+            className={`mk-navlink capitalize ${tab === t ? "underline" : ""}`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      {items === null && <p className="opacity-60">Loading…</p>}
+      {items?.length === 0 && <p className="mk-card px-4 py-6 opacity-70">Queue is empty. Good sign.</p>}
+      <ul className="space-y-3">
+        {(items ?? []).map((r) => (
+          <li key={r.id} className="mk-card px-4 py-3" data-testid="report-row">
+            <p className="text-[0.85rem]">
+              <span className="mk-eyebrow mr-2">{r.reason}</span>
+              <Link href={`/community/t/${r.topic_id}/x#post-${r.post_number}`} className="font-medium hover:underline">
+                {r.topic_title} #{r.post_number}
+              </Link>
+              <span className="ml-2 opacity-60">reported by {r.reporter ?? "a deleted user"}</span>
+            </p>
+            {r.detail && <p className="mt-1 text-[0.85rem] opacity-70">{r.detail}</p>}
+            <p className="mt-1 text-[0.8rem] opacity-60">“{r.post_excerpt}”</p>
+            {tab === "open" && (
+              <button
+                type="button"
+                className="mk-btn mk-btn--primary mt-2 h-7 px-3 text-[0.78rem]"
+                onClick={async () => {
+                  await communityApi.resolveReport(r.id).catch(() => undefined);
+                  load();
+                }}
+              >
+                Resolve
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web/src/app/(marketing)/community/t/[id]/[[...slug]]/page.tsx
+++ b/web/src/app/(marketing)/community/t/[id]/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import { notFound, permanentRedirect } from "next/navigation";
 
 import { LikeButton, ThreadEngagement } from "@/components/community/engagement";
 import { PostBody } from "@/components/community/post-body";
+import { ReportButton, StaffPostDelete, StaffTopicControls } from "@/components/community/staff-tools";
 import { PostControls, ReplyBox } from "@/components/community/thread-actions";
 import { getPosts, getTopic } from "@/lib/api/community-server";
 
@@ -65,6 +66,7 @@ export default async function TopicPage({
         {" · "}
         {new Date(topic.created_at).toLocaleDateString()} · {topic.reply_count} replies · {topic.view_count} views
       </p>
+      <StaffTopicControls topicId={topic.id} pinned={topic.is_pinned} locked={topic.is_locked} />
 
       <ThreadEngagement topicId={topic.id} maxPostNumber={posts.items.length ? posts.items[posts.items.length - 1].post_number : 1}>
       <ol className="space-y-6">
@@ -91,6 +93,9 @@ export default async function TopicPage({
                   {post.edited_at && <em> · edited</em>}
                   {" · "}
                   <LikeButton postId={post.id} initialCount={post.like_count ?? 0} />
+                  {" · "}
+                  <ReportButton postId={post.id} authorId={post.author?.id ?? null} />
+                  <StaffPostDelete postId={post.id} authorId={post.author?.id ?? null} />
                 </p>
                 <PostBody content={post.content ?? ""} />
                 <PostControls

--- a/web/src/components/community/staff-tools.tsx
+++ b/web/src/components/community/staff-tools.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+/** Report (any member) and moderation (staff) islands for thread pages.
+ *  Staff visibility keys off is_staff on /auth/me — the server enforces
+ *  either way; hiding is courtesy, not security. */
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { communityApi } from "@/lib/api/endpoints";
+import { useAuthStore } from "@/lib/stores/auth-store";
+
+export function ReportButton({ postId, authorId }: { postId: string; authorId: string | null }) {
+  const user = useAuthStore((s) => s.user);
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("spam");
+  const [detail, setDetail] = useState("");
+  const [state, setState] = useState<"idle" | "sent" | "dup">("idle");
+
+  if (!user || user.id === authorId) return null;
+  if (state === "sent") return <span className="text-[0.78rem] opacity-60">Reported — staff will look.</span>;
+  if (state === "dup") return <span className="text-[0.78rem] opacity-60">You already reported this.</span>;
+
+  if (!open) {
+    return (
+      <button type="button" className="text-[0.78rem] opacity-60 hover:underline hover:opacity-100" onClick={() => setOpen(true)}>
+        Report
+      </button>
+    );
+  }
+  return (
+    <span className="inline-flex flex-wrap items-center gap-2 text-[0.8rem]">
+      <select value={reason} onChange={(e) => setReason(e.target.value)} className="mk-card px-2 py-1" aria-label="Reason">
+        <option value="spam">Spam</option>
+        <option value="abuse">Abuse</option>
+        <option value="off-topic">Off topic</option>
+        <option value="other">Other</option>
+      </select>
+      <input
+        value={detail}
+        onChange={(e) => setDetail(e.target.value)}
+        placeholder="Anything staff should know (optional)"
+        className="mk-card w-60 px-2 py-1"
+        aria-label="Report detail"
+      />
+      <button
+        type="button"
+        className="mk-btn mk-btn--primary h-7 px-3 text-[0.78rem]"
+        onClick={async () => {
+          try {
+            await communityApi.report(postId, reason, detail);
+            setState("sent");
+          } catch (e) {
+            setState(e instanceof Error && e.message.includes("already") ? "dup" : "sent");
+          }
+        }}
+      >
+        Send
+      </button>
+      <button type="button" className="opacity-60 hover:underline" onClick={() => setOpen(false)}>
+        Cancel
+      </button>
+    </span>
+  );
+}
+
+export function StaffTopicControls({
+  topicId,
+  pinned,
+  locked,
+}: {
+  topicId: string;
+  pinned: boolean;
+  locked: boolean;
+}) {
+  const user = useAuthStore((s) => s.user);
+  const router = useRouter();
+  if (!user?.is_staff) return null;
+
+  const act = async (patch: { pinned?: boolean; locked?: boolean }) => {
+    await communityApi.moderateTopic(topicId, patch).catch(() => undefined);
+    router.refresh();
+  };
+  return (
+    <p className="mk-card mt-2 inline-flex items-center gap-3 px-3 py-1.5 text-[0.8rem]" data-testid="staff-controls">
+      <span className="mk-eyebrow">Staff</span>
+      <button type="button" className="hover:underline" onClick={() => act({ pinned: !pinned })}>
+        {pinned ? "Unpin" : "Pin"}
+      </button>
+      <button type="button" className="hover:underline" onClick={() => act({ locked: !locked })}>
+        {locked ? "Unlock" : "Lock"}
+      </button>
+      <button
+        type="button"
+        className="text-red-400 hover:underline"
+        onClick={async () => {
+          if (!window.confirm("Delete this whole topic?")) return;
+          await communityApi.staffDeleteTopic(topicId).catch(() => undefined);
+          router.push("/community");
+          router.refresh();
+        }}
+      >
+        Delete topic
+      </button>
+    </p>
+  );
+}
+
+export function StaffPostDelete({ postId, authorId }: { postId: string; authorId: string | null }) {
+  const user = useAuthStore((s) => s.user);
+  const router = useRouter();
+  if (!user?.is_staff || user.id === authorId) return null;
+  return (
+    <button
+      type="button"
+      className="text-[0.78rem] text-red-400 hover:underline"
+      onClick={async () => {
+        if (!window.confirm("Remove this post?")) return;
+        await communityApi.staffDeletePost(postId).catch(() => undefined);
+        router.refresh();
+      }}
+    >
+      Remove (staff)
+    </button>
+  );
+}

--- a/web/src/lib/api/endpoints.ts
+++ b/web/src/lib/api/endpoints.ts
@@ -12,6 +12,7 @@ import type {
   CanvasData,
   CanvasFull,
   CanvasMeta,
+  CommunityReportItem,
   FolderInfo,
   Graph,
   ApiKey,
@@ -383,6 +384,17 @@ export const communityApi = {
     apiJson<{ id: string }>(`/community/posts/${postId}`, "PATCH", { content }),
   deletePost: (postId: string) => apiJson<{ deleted: string }>(`/community/posts/${postId}`, "DELETE"),
   deleteTopic: (topicId: string) => apiJson<{ deleted: string }>(`/community/topics/${topicId}`, "DELETE"),
+  report: (postId: string, reason: string, detail: string) =>
+    apiJson<{ id: string }>(`/community/posts/${postId}/report`, "POST", { reason, detail }),
+  // Staff:
+  moderateTopic: (topicId: string, patch: { pinned?: boolean; locked?: boolean; category?: string }) =>
+    apiJson<{ id: string }>(`/community/topics/${topicId}`, "PATCH", patch),
+  staffDeletePost: (postId: string) => apiJson<{ deleted: string }>(`/community/mod/posts/${postId}`, "DELETE"),
+  staffDeleteTopic: (topicId: string) => apiJson<{ deleted: string }>(`/community/mod/topics/${topicId}`, "DELETE"),
+  listReports: (status: "open" | "resolved") =>
+    api<{ items: CommunityReportItem[]; total: number }>(`/community/mod/reports?status=${status}`),
+  resolveReport: (reportId: string) =>
+    apiJson<{ id: string; status: string }>(`/community/mod/reports/${reportId}/resolve`, "POST"),
 };
 
 export const apiKeysApi = {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -337,3 +337,20 @@ export interface ApiKeyList {
 }
 
 export type ApiKeyWithToken = ApiKey & { token: string; base_url: string };
+
+// ── Community ────────────────────────────────────────────────────────────────
+
+export interface CommunityReportItem {
+  id: string;
+  post_id: string;
+  topic_id: string;
+  topic_title: string;
+  post_number: number;
+  post_excerpt: string;
+  reason: string;
+  detail: string | null;
+  reporter: string | null;
+  status: string;
+  created_at: string;
+}
+


### PR DESCRIPTION
Inline reporting (one per post), staff topic controls (pin/lock/delete) and the /community/mod queue with resolve. Three-context e2e moderation cycle. Plan: tasks/nodum-community-plan.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)