### PR TITLE
feat(web): GitHub icon beside Log in

### DIFF
--- a/web/src/components/marketing/site-chrome.tsx
+++ b/web/src/components/marketing/site-chrome.tsx
@@ -35,12 +35,21 @@ export function SiteNav() {
           <Link className="mk-navlink" href="/faq">
             FAQ
           </Link>
-          <a className="mk-navlink" href={GITHUB} target="_blank" rel="noreferrer">
-            GitHub
-          </a>
         </nav>
 
         <div className="flex items-center gap-2 sm:gap-3">
+          <a
+            href={GITHUB}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Nodum on GitHub"
+            title="Nodum on GitHub"
+            className="mk-navlink flex size-9 items-center justify-center p-0"
+          >
+            <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+            </svg>
+          </a>
           <Link href="/login" className="mk-navlink px-2 py-1">
             Log in
           </Link>


### PR DESCRIPTION
The GitHub link moves out of the center nav into the right-hand action group as an icon button with an accessible name; footer link unchanged. make verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)