### PR TITLE
feat(dev): agentation visual-feedback toolbar

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -56,6 +56,7 @@
         "@types/node": "^26.2.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "agentation": "^3.0.2",
         "eslint": "^9.39.5",
         "eslint-config-next": "16.3.1",
         "tailwindcss": "^4",
@@ -7696,6 +7697,25 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentation": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/agentation/-/agentation-3.0.2.tgz",
+      "integrity": "sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA==",
+      "dev": true,
+      "license": "PolyForm-Shield-1.0.0",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/ai": {

--- a/web/package.json
+++ b/web/package.json
@@ -59,6 +59,7 @@
     "@types/node": "^26.2.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "agentation": "^3.0.2",
     "eslint": "^9.39.5",
     "eslint-config-next": "16.3.1",
     "tailwindcss": "^4",

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
+import { AgentationDevTools } from "@/components/dev/agentation-dev-tools";
 import { Providers } from "./providers";
 
 import { PRIMARY } from "@/lib/seo/keywords";
@@ -103,6 +104,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           title="All site content as markdown"
         />
         <Providers>{children}</Providers>
+        <AgentationDevTools />
       </body>
     </html>
   );

--- a/web/src/components/dev/agentation-dev-tools.tsx
+++ b/web/src/components/dev/agentation-dev-tools.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+/**
+ * Agentation (https://github.com/benjitaylor/agentation): a dev-only visual
+ * feedback toolbar. Click elements on the running app, annotate them, and it
+ * produces structured markdown (selectors, React component hierarchy, source
+ * locations) to paste into an AI coding agent.
+ *
+ * The NODE_ENV check is evaluated at build time, so the module-scope
+ * conditional prunes the entire package from production bundles — prod ships
+ * zero agentation bytes. (License: PolyForm Shield — fine as an internal dev
+ * tool; it is a devDependency and never redistributed.)
+ */
+
+import dynamic from "next/dynamic";
+
+const Agentation =
+  process.env.NODE_ENV === "development"
+    ? dynamic(() => import("agentation").then((m) => m.Agentation), { ssr: false })
+    : null;
+
+export function AgentationDevTools() {
+  if (!Agentation) return null;
+  return <Agentation />;
+}


### PR DESCRIPTION
npm agentation (3.0.2) mounted as a dev-only client component in the root layout — annotate elements in the running app and paste structured selectors/component-tree markdown into an AI agent. Build-time NODE_ENV gate; a clean prod build greps to zero agentation bytes. devDependency; PolyForm Shield license (internal tooling, not redistributed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)