### PR TITLE
feat(web): host-based sections — subdomains

### DIFF
--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -28,6 +28,10 @@
 #   nodum.example.com   -> automatic HTTPS
 #   :80                 -> plain HTTP, no ACME (only behind another TLS terminator)
 NODUM_SITE_ADDRESS=nodum.example.com
+# Optional host-based sections (needs a DNS record per host; Caddy fetches
+# certificates for each). Set BOTH lines or neither:
+#NODUM_SUBDOMAIN_ADDRESSES=docs.nodum.example.com developers.nodum.example.com community.nodum.example.com forum.nodum.example.com
+#NODUM_ENABLE_SUBDOMAIN_REDIRECTS=1
 
 # Host ports the edge proxy publishes. Only change these if something else
 # already owns 80/443, or to run this stack locally for verification.

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -22,7 +22,11 @@
 	}
 }
 
-{$NODUM_SITE_ADDRESS::80} {
+# NODUM_SUBDOMAIN_ADDRESSES (optional): space-separated extra hosts served by
+# the same block — "docs.nodum.md developers.nodum.md community.nodum.md
+# forum.nodum.md". Each needs a DNS record; Caddy provisions certificates for
+# every listed host. The web app's middleware maps each host to its section.
+{$NODUM_SITE_ADDRESS::80} {$NODUM_SUBDOMAIN_ADDRESSES:} {
 	encode zstd gzip
 
 	header {

--- a/deploy/docker-compose.deploy.yml
+++ b/deploy/docker-compose.deploy.yml
@@ -362,11 +362,13 @@ services:
       args:
         NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
         API_PROXY_URL: http://api:8000
+      NODUM_ENABLE_SUBDOMAIN_REDIRECTS: ${NODUM_ENABLE_SUBDOMAIN_REDIRECTS:-}
     image: nodum-web:${NODUM_IMAGE_TAG:-latest}
     <<: *hardening
     environment:
       NODE_ENV: production
       API_PROXY_URL: http://api:8000
+      NODUM_ENABLE_SUBDOMAIN_REDIRECTS: ${NODUM_ENABLE_SUBDOMAIN_REDIRECTS:-}
       SENTRY_DSN: ${SENTRY_DSN:-}
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/"]
@@ -392,6 +394,7 @@ services:
     <<: *hardening
     environment:
       NODUM_SITE_ADDRESS: ${NODUM_SITE_ADDRESS:-:80}
+      NODUM_SUBDOMAIN_ADDRESSES: ${NODUM_SUBDOMAIN_ADDRESSES:-}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/deploy/docker-compose.deploy.yml
+++ b/deploy/docker-compose.deploy.yml
@@ -362,7 +362,6 @@ services:
       args:
         NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
         API_PROXY_URL: http://api:8000
-      NODUM_ENABLE_SUBDOMAIN_REDIRECTS: ${NODUM_ENABLE_SUBDOMAIN_REDIRECTS:-}
     image: nodum-web:${NODUM_IMAGE_TAG:-latest}
     <<: *hardening
     environment:

--- a/web/e2e/subdomains.spec.ts
+++ b/web/e2e/subdomains.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+/** Host-based sections: docs./developers./community./forum. serve their
+ *  section at the root of the subdomain, cross-section paths bounce to the
+ *  right host, and the apex keeps serving everything while the redirect
+ *  flag is off (as in dev). Browsers resolve *.localhost natively; the
+ *  request-fixture cases override the Host header to skip OS DNS. */
+
+const APEX = new URL(process.env.BASE_URL ?? "http://localhost:3000").host;
+
+test.describe("host-based sections", () => {
+  test("each subdomain serves its section from its root", async ({ page }) => {
+    test.setTimeout(60_000);
+    await page.goto(`http://docs.${APEX}/`);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("What every part of Nodum is for");
+    await page.goto(`http://docs.${APEX}/mcp`);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("MCP");
+
+    await page.goto(`http://forum.${APEX}/`);
+    await expect(page.getByRole("heading", { name: "Talk Nodum" })).toBeVisible();
+
+    await page.goto(`http://community.${APEX}/`);
+    await expect(page.getByRole("heading", { name: "Built in the open" })).toBeVisible();
+
+    await page.goto(`http://developers.${APEX}/`);
+    await expect(page.getByRole("heading", { name: "Nodum API" })).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("prefixed and cross-section paths land on their proper hosts", async ({ request }) => {
+    const base = `http://${APEX}`;
+    // A section's own prefix canonicalizes to the root form.
+    const prefixed = await request.get(`${base}/docs/mcp`, {
+      headers: { Host: `docs.${APEX}` },
+      maxRedirects: 0,
+    });
+    expect(prefixed.status()).toBe(308);
+    expect(prefixed.headers()["location"]).toContain(`docs.${APEX}/mcp`);
+
+    // Another section's path 307s to that section's host, rooted.
+    const stray = await request.get(`${base}/docs/mcp`, {
+      headers: { Host: `forum.${APEX}` },
+      maxRedirects: 0,
+    });
+    expect(stray.status()).toBe(307);
+    expect(stray.headers()["location"]).toContain(`docs.${APEX}/mcp`);
+    expect(stray.headers()["location"]).not.toContain("forum.");
+
+    // App-shell paths pass through untouched on any host.
+    const login = await request.get(`${base}/login`, {
+      headers: { Host: `docs.${APEX}` },
+      maxRedirects: 0,
+    });
+    expect(login.status()).toBe(200);
+
+    // The apex is untouched while the redirect flag is off.
+    const apex = await request.get(`${base}/docs`, { maxRedirects: 0 });
+    expect(apex.status()).toBe(200);
+    const apexRef = await request.get(`${base}/api-reference`, { maxRedirects: 0 });
+    expect(apexRef.status()).toBe(200);
+  });
+});

--- a/web/e2e/subdomains.spec.ts
+++ b/web/e2e/subdomains.spec.ts
@@ -6,7 +6,8 @@ import { expect, test } from "@playwright/test";
  *  flag is off (as in dev). Browsers resolve *.localhost natively; the
  *  request-fixture cases override the Host header to skip OS DNS. */
 
-const APEX = new URL(process.env.BASE_URL ?? "http://localhost:3000").host;
+// CI serves on 127.0.0.1 — an IP cannot take subdomains, localhost can.
+const APEX = new URL(process.env.BASE_URL ?? "http://localhost:3000").host.replace("127.0.0.1", "localhost");
 
 test.describe("host-based sections", () => {
   test("each subdomain serves its section from its root", async ({ page }) => {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,0 +1,93 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Host-based sections: docs.<domain>, developers.<domain>, community.<domain>
+ * and forum.<domain> serve their section at the root, backed by the same app.
+ *
+ * Rules on a section host:
+ * - Its own prefixed path canonicalizes to the rooted form (docs.x/docs/mcp
+ *   308→ docs.x/mcp).
+ * - Another section's path 307s to THAT section's host, rooted (forum.x/docs/
+ *   mcp → docs.x/mcp). Never to the apex: this Next relativizes Location
+ *   headers that match its own origin, and a relative Location on a foreign
+ *   host would loop.
+ * - Everything else rewrites into the section (docs.x/mcp → /docs/mcp) —
+ *   except app paths (/login, /vault, …), which pass through untouched so
+ *   the chrome's links keep working anywhere.
+ *
+ * The apex serves every path as before; only with
+ * NODUM_ENABLE_SUBDOMAIN_REDIRECTS set (production, DNS in place) does it
+ * push section paths out to their subdomains.
+ *
+ * Works on *.localhost in development — browsers resolve it natively.
+ */
+
+const SECTIONS: Record<string, { prefix: string; exact?: boolean }> = {
+  docs: { prefix: "/docs" },
+  developers: { prefix: "/api-reference", exact: true },
+  community: { prefix: "/community", exact: true },
+  forum: { prefix: "/forum" },
+};
+
+/** Paths that belong to the app shell, never to a section. */
+const PASS_THROUGH = ["/login", "/signup", "/vault", "/p/", "/s/", "/clip", "/llms.txt"];
+
+function sectionOfPath(pathname: string): string | null {
+  for (const [sub, { prefix }] of Object.entries(SECTIONS)) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) return sub;
+  }
+  return null;
+}
+
+/** An absolute-Location redirect Next cannot relativize. */
+function hostRedirect(url: string, status: 307 | 308) {
+  return new NextResponse(null, { status, headers: { Location: url } });
+}
+
+export function proxy(request: NextRequest) {
+  const host = request.headers.get("host") ?? "";
+  const [first, ...rest] = host.split(".");
+  const section = SECTIONS[first] && rest.length > 0 ? first : null;
+  const { pathname, search } = request.nextUrl;
+  const proto = request.nextUrl.protocol;
+
+  if (section) {
+    const apexHost = rest.join(".");
+    const { prefix, exact } = SECTIONS[section];
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      const rooted = pathname.slice(prefix.length) || "/";
+      return hostRedirect(`${proto}//${host}${rooted}${search}`, 308);
+    }
+    const other = sectionOfPath(pathname);
+    if (other && other !== section) {
+      const otherPrefix = SECTIONS[other].prefix;
+      const rooted = pathname.slice(otherPrefix.length) || "/";
+      return hostRedirect(`${proto}//${other}.${apexHost}${rooted}${search}`, 307);
+    }
+    if (PASS_THROUGH.some((p) => pathname === p || pathname.startsWith(p))) {
+      return NextResponse.next();
+    }
+    if (exact && pathname !== "/") {
+      // Sections without subpaths: serve the apex's page under this host
+      // rather than redirect (an apex-target Location would relativize).
+      return NextResponse.next();
+    }
+    const url = request.nextUrl.clone();
+    url.pathname = pathname === "/" ? prefix : `${prefix}${pathname}`;
+    return NextResponse.rewrite(url);
+  }
+
+  if (process.env.NODUM_ENABLE_SUBDOMAIN_REDIRECTS) {
+    const target = sectionOfPath(pathname);
+    if (target) {
+      const { prefix } = SECTIONS[target];
+      const rooted = pathname.slice(prefix.length) || "/";
+      return hostRedirect(`${proto}//${target}.${host}${rooted}${search}`, 308);
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|_next/data|favicon.ico|.*\\..*).*)"],
+};


### PR DESCRIPTION
docs./developers./community./forum.<domain> serve their sections at the root via Next 16's proxy.ts (canonicalizing 308s, cross-section 307s to the right host, app-shell pass-through — the apex-relativization loop is pinned by e2e); Caddy gains NODUM_SUBDOMAIN_ADDRESSES on the same block (validated both ways); apex pushes section paths out only when NODUM_ENABLE_SUBDOMAIN_REDIRECTS is set. 30 tests across affected suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)