### PR TITLE
chore: release v3.6.1

### DIFF
--- a/back/app/settings/common.py
+++ b/back/app/settings/common.py
@@ -43,7 +43,7 @@ class CommonSettings(BaseSettings):
 
     # ── Application ───────────────────────────────────────────────────────────
     APP_NAME: str = "Nodum"
-    APP_VERSION: str = "3.6.0"
+    APP_VERSION: str = "3.6.1"
     ENVIRONMENT: Annotated[
         Literal["dev", "test", "staging", "production"],
         BeforeValidator(normalize_environment),

--- a/tasks/nodum-master-plan.md
+++ b/tasks/nodum-master-plan.md
@@ -223,6 +223,15 @@ gitleaks clean → pushed to github.com/vorreix/nodum. Released as v1.0.0.
 
 ## 6. Progress Log
 
+- **2026-08-21 (v3.6.1 — subdomain hotfix from the first prod deploy)** —
+  nodum.md went live with the redirect flag on before its subdomain DNS
+  existed, which surfaced three holes at once: redirects emitted http://
+  (now honor X-Forwarded-Proto behind the TLS terminator), /api-reference
+  never redirected (the proxy matcher excluded "api" instead of "api/"),
+  and smoke.sh printed a bare 308 where it now follows the redirect and
+  names the unresolvable host with both remedies. Also: CI's e2e now runs
+  only on the release PR (main<-dev) plus manual dispatch (PR #42).
+
 - **2026-08-21 (v3.6.0 released — the site grows up: subdomains, hub, dev tooling)** —
   Four PRs (#36–#39): the GitHub link becomes an icon beside Log in; the
   agentation toolbar joins dev builds (annotate the running app, paste


### PR DESCRIPTION
Patch bump for the subdomain hotfix (forwarded proto, matcher, smoke diagnosis) + the e2e-on-release-PR-only CI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)