### PR TITLE
release v3.6.1

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,9 +1,12 @@
 name: CI E2E
 
+# The full-stack Playwright suite is the slowest gate in CI (~17 min), so it
+# runs only where it decides something: the release PR (main <- dev). Every
+# feature branch still runs it locally (make e2e is part of the merge ritual),
+# and workflow_dispatch stays as the manual escape hatch.
 on:
-  push:
-    branches: [main, dev]
   pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -19,6 +22,8 @@ env:
 jobs:
   e2e:
     name: Playwright (full stack)
+    # Belt to the trigger's braces: only the dev branch releases into main.
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'dev'
     runs-on: ubuntu-latest
     timeout-minutes: 40
 

--- a/back/app/settings/common.py
+++ b/back/app/settings/common.py
@@ -43,7 +43,7 @@ class CommonSettings(BaseSettings):
 
     # ── Application ───────────────────────────────────────────────────────────
     APP_NAME: str = "Nodum"
-    APP_VERSION: str = "3.6.0"
+    APP_VERSION: str = "3.6.1"
     ENVIRONMENT: Annotated[
         Literal["dev", "test", "staging", "production"],
         BeforeValidator(normalize_environment),

--- a/deploy/smoke.sh
+++ b/deploy/smoke.sh
@@ -136,10 +136,23 @@ oa=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/api/public/v1/openapi.json")
 # ── the community forum: publicly readable, categories seeded ────────────────
 cm=$(curl -s "$BASE/api/v1/community/categories")
 echo "$cm" | grep -q '"announcements"' && ok "community categories seeded" || bad "community categories: ${cm:0:160}"
-cp=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/community")
-[ "$cp" = 200 ] && ok "community hub served" || bad "/community returned $cp"
-fp=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/forum")
-[ "$fp" = 200 ] && ok "forum served" || bad "/forum returned $fp"
+# -L: with subdomain redirects enabled these paths 308 to their subdomains —
+# following is the point, because a redirect to a host without a DNS record
+# is exactly the misconfiguration this check must catch.
+check_public_page() {
+  out=$(curl -sL -o /dev/null -m 20 -w '%{http_code} %{url_effective}' "$BASE$1")
+  code=${out%% *}; final=${out#* }
+  if [ "$code" = 200 ]; then
+    ok "$2 served (${final})"
+  elif [ "$code" = 000 ]; then
+    bad "$1 redirects to ${final} which does not resolve — add its DNS record or unset NODUM_ENABLE_SUBDOMAIN_REDIRECTS"
+  else
+    bad "$1 returned $code (final: ${final})"
+  fi
+}
+check_public_page /community "community hub"
+check_public_page /forum "forum"
+check_public_page /docs "docs"
 
 # ── the load-bearing one: attachment upload + fetch via the /s3 proxy route ──
 printf 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==' | base64 -d > /tmp/smoke.png

--- a/tasks/nodum-master-plan.md
+++ b/tasks/nodum-master-plan.md
@@ -223,6 +223,15 @@ gitleaks clean → pushed to github.com/vorreix/nodum. Released as v1.0.0.
 
 ## 6. Progress Log
 
+- **2026-08-21 (v3.6.1 — subdomain hotfix from the first prod deploy)** —
+  nodum.md went live with the redirect flag on before its subdomain DNS
+  existed, which surfaced three holes at once: redirects emitted http://
+  (now honor X-Forwarded-Proto behind the TLS terminator), /api-reference
+  never redirected (the proxy matcher excluded "api" instead of "api/"),
+  and smoke.sh printed a bare 308 where it now follows the redirect and
+  names the unresolvable host with both remedies. Also: CI's e2e now runs
+  only on the release PR (main<-dev) plus manual dispatch (PR #42).
+
 - **2026-08-21 (v3.6.0 released — the site grows up: subdomains, hub, dev tooling)** —
   Four PRs (#36–#39): the GitHub link becomes an icon beside Log in; the
   agentation toolbar joins dev builds (annotate the running app, paste

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -49,7 +49,11 @@ export function proxy(request: NextRequest) {
   const [first, ...rest] = host.split(".");
   const section = SECTIONS[first] && rest.length > 0 ? first : null;
   const { pathname, search } = request.nextUrl;
-  const proto = request.nextUrl.protocol;
+  // Behind the TLS-terminating proxy the container only ever sees http —
+  // redirects must use the protocol the CLIENT used, or https pages bounce
+  // to http:// URLs.
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  const proto = forwardedProto ? `${forwardedProto}:` : request.nextUrl.protocol;
 
   if (section) {
     const apexHost = rest.join(".");
@@ -89,5 +93,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|_next/data|favicon.ico|.*\\..*).*)"],
+  matcher: ["/((?!api/|_next/static|_next/image|_next/data|favicon.ico|.*\\..*).*)"],
 };


### PR DESCRIPTION
Patch release: subdomain redirects honor X-Forwarded-Proto (they emitted http:// behind the TLS terminator), /api-reference joins the apex redirects (proxy matcher excluded 'api' not 'api/'), smoke.sh follows redirects and diagnoses unresolvable targets by name, and CI's e2e now runs only on this very kind of PR (#42). Verified flag-on locally and flag-off across 12 e2e; make verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)