### PR TITLE
fix(deploy): guard the half-configured subdomain split

### DIFF
--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -28,8 +28,16 @@
 #   nodum.example.com   -> automatic HTTPS
 #   :80                 -> plain HTTP, no ACME (only behind another TLS terminator)
 NODUM_SITE_ADDRESS=nodum.example.com
-# Optional host-based sections (needs a DNS record per host; Caddy fetches
-# certificates for each). Set BOTH lines or neither:
+# Optional host-based sections (docs./developers./community./forum.), each
+# needing its own DNS record.
+#
+#   This stack terminates TLS (NODUM_SITE_ADDRESS is a hostname, as above):
+#     set BOTH lines — the addresses tell this Caddy to serve and certificate
+#     those hosts, the flag makes the apex redirect to them.
+#   Something else terminates TLS (NODUM_SITE_ADDRESS is ":80"/":443", i.e. a
+#     reverse proxy or load balancer in front): set ONLY the flag, and add the
+#     hosts to THAT proxy instead. Naming them here would switch on automatic
+#     HTTPS inside the stack and answer every section with a 308 to itself.
 #NODUM_SUBDOMAIN_ADDRESSES=docs.nodum.example.com developers.nodum.example.com community.nodum.example.com forum.nodum.example.com
 #NODUM_ENABLE_SUBDOMAIN_REDIRECTS=1
 

--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -67,6 +67,30 @@ resolve_env_file() {
     exit 1
 }
 
+# ── Preflight: the two subdomain switches must agree ────────
+# NODUM_ENABLE_SUBDOMAIN_REDIRECTS sends /docs, /community, /forum and
+# /api-reference to their subdomains; NODUM_SUBDOMAIN_ADDRESSES is what makes
+# Caddy serve (and certificate) those hosts. With only the first, every
+# section link becomes a dead redirect to a host that answers no TLS at all —
+# a live-site outage that reads like a DNS problem. Refuse the deploy instead.
+check_subdomain_pairing() {
+    local file="$1" redirects addresses
+    redirects=$(sed -n 's/^[[:space:]]*NODUM_ENABLE_SUBDOMAIN_REDIRECTS=//p' "$file" | tail -1)
+    addresses=$(sed -n 's/^[[:space:]]*NODUM_SUBDOMAIN_ADDRESSES=//p' "$file" | tail -1)
+    redirects=$(printf '%s' "$redirects" | tr -d '"' | tr -d "'" | tr -d ' ')
+    addresses=$(printf '%s' "$addresses" | tr -d '"' | tr -d "'" | tr -d ' ')
+    if [ -n "$redirects" ] && [ -z "$addresses" ]; then
+        echo "ERROR: NODUM_ENABLE_SUBDOMAIN_REDIRECTS is set in $file but" >&2
+        echo "       NODUM_SUBDOMAIN_ADDRESSES is not (is that line still commented out?)." >&2
+        echo "       The apex would redirect /docs, /community, /forum and /api-reference" >&2
+        echo "       to hosts this stack does not serve: no certificate, no page." >&2
+        echo "       Set both (a DNS record per host is required), for example:" >&2
+        echo "         NODUM_SUBDOMAIN_ADDRESSES=docs.example.com developers.example.com community.example.com forum.example.com" >&2
+        echo "       or drop NODUM_ENABLE_SUBDOMAIN_REDIRECTS to keep every section on the apex." >&2
+        exit 1
+    fi
+}
+
 # ── Compose invocation ──────────────────────────────────────
 # ENVIRONMENT and the image tag are exported here rather than read from the
 # env file: which stack you asked for is decided by the argument you typed,
@@ -111,12 +135,14 @@ case "$ENV" in
         ;;
     staging)
         resolve_env_file staging
+        check_subdomain_pairing "$env_file"
         export NODUM_ENVIRONMENT=staging NODUM_IMAGE_TAG="${NODUM_IMAGE_TAG:-staging}"
         collect_deploy_files docker-compose.staging.yml
         run nodum-staging "${FILES[@]}"
         ;;
     prod)
         resolve_env_file prod
+        check_subdomain_pairing "$env_file"
         export NODUM_ENVIRONMENT=production NODUM_IMAGE_TAG="${NODUM_IMAGE_TAG:-prod}"
         collect_deploy_files docker-compose.prod.yml
         run nodum-prod "${FILES[@]}"

--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -74,11 +74,21 @@ resolve_env_file() {
 # section link becomes a dead redirect to a host that answers no TLS at all —
 # a live-site outage that reads like a DNS problem. Refuse the deploy instead.
 check_subdomain_pairing() {
-    local file="$1" redirects addresses
+    local file="$1" redirects addresses site
     redirects=$(sed -n 's/^[[:space:]]*NODUM_ENABLE_SUBDOMAIN_REDIRECTS=//p' "$file" | tail -1)
     addresses=$(sed -n 's/^[[:space:]]*NODUM_SUBDOMAIN_ADDRESSES=//p' "$file" | tail -1)
+    site=$(sed -n 's/^[[:space:]]*NODUM_SITE_ADDRESS=//p' "$file" | tail -1)
     redirects=$(printf '%s' "$redirects" | tr -d '"' | tr -d "'" | tr -d ' ')
     addresses=$(printf '%s' "$addresses" | tr -d '"' | tr -d "'" | tr -d ' ')
+    site=$(printf '%s' "$site" | tr -d '"' | tr -d "'" | tr -d ' ')
+    # A port-only site address (":80", ":443") means something else terminates
+    # TLS in front and forwards every Host to this stack. There the stack must
+    # NOT name the section hosts — naming them switches on automatic HTTPS and
+    # the inner Caddy answers each one with a 308 to itself. The front proxy
+    # owns those names; nothing to pair here.
+    case "$site" in
+        :*|"") return ;;
+    esac
     if [ -n "$redirects" ] && [ -z "$addresses" ]; then
         echo "ERROR: NODUM_ENABLE_SUBDOMAIN_REDIRECTS is set in $file but" >&2
         echo "       NODUM_SUBDOMAIN_ADDRESSES is not (is that line still commented out?)." >&2

--- a/deploy/smoke.sh
+++ b/deploy/smoke.sh
@@ -140,16 +140,28 @@ echo "$cm" | grep -q '"announcements"' && ok "community categories seeded" || ba
 # following is the point, because a redirect to a host without a DNS record
 # is exactly the misconfiguration this check must catch.
 check_public_page() {
-  out=$(curl -sL -o /dev/null -m 20 -w '%{http_code} %{url_effective}' "$BASE$1")
+  local path="$1" label="$2" out code final rc
+  out=$(curl -sL -o /dev/null -m 20 -w '%{http_code} %{url_effective}' "$BASE$path"); rc=$?
   code=${out%% *}; final=${out#* }
   if [ "$code" = 200 ]; then
-    ok "$2 served (${final})"
-  elif [ "$code" = 000 ]; then
-    bad "$1 redirects to ${final} which does not resolve — add its DNS record or unset NODUM_ENABLE_SUBDOMAIN_REDIRECTS"
+    if [ "$final" = "$BASE$path" ] || [ "$final" = "$BASE$path/" ]; then
+      ok "$label served"
+    else
+      ok "$label served via ${final}"
+    fi
+  elif [ "${final#"$BASE"}" = "$final" ]; then
+    # The chain left this origin and then failed: the subdomain is redirected
+    # to but not served — the classic half-configured split.
+    bad "$path redirects to ${final} which does not answer (curl $rc)."
+    echo "      ↳ that host needs BOTH a DNS record and an entry in" >&2
+    echo "        NODUM_SUBDOMAIN_ADDRESSES in .env.prod (check it is not commented out)," >&2
+    echo "        then ./compose.sh prod up -d so caddy is recreated with it." >&2
+    echo "        Or drop NODUM_ENABLE_SUBDOMAIN_REDIRECTS to keep sections on the apex." >&2
   else
-    bad "$1 returned $code (final: ${final})"
+    bad "$path returned $code (final: ${final})"
   fi
 }
+
 check_public_page /community "community hub"
 check_public_page /forum "forum"
 check_public_page /docs "docs"


### PR DESCRIPTION
compose.sh refuses staging/prod when NODUM_ENABLE_SUBDOMAIN_REDIRECTS is set without NODUM_SUBDOMAIN_ADDRESSES (the state that just took nodum.md's sections down), and smoke.sh now names the redirected-to-but-unserved host instead of printing a bare 308. Guard proved against four env-file cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)