### PR TITLE
feat(web): Developers link in the navbar

### DIFF
--- a/web/e2e/subdomains.spec.ts
+++ b/web/e2e/subdomains.spec.ts
@@ -59,4 +59,20 @@ test.describe("host-based sections", () => {
     const apexRef = await request.get(`${base}/api-reference`, { maxRedirects: 0 });
     expect(apexRef.status()).toBe(200);
   });
+
+  test("the navbar's Developers link reaches the API reference", async ({ page, request }) => {
+    // Apex install: the link serves the reference in place.
+    await page.goto("/");
+    await page.getByRole("link", { name: "Developers", exact: true }).click();
+    await expect(page).toHaveURL(/\/api-reference/);
+    await expect(page.getByRole("heading", { name: "Nodum API" })).toBeVisible({ timeout: 20_000 });
+
+    // On a section host the same path canonicalizes onto developers.<domain>.
+    const hop = await request.get(`http://${APEX}/api-reference`, {
+      headers: { Host: `developers.${APEX}` },
+      maxRedirects: 0,
+    });
+    expect(hop.status()).toBe(308);
+    expect(hop.headers()["location"]).toContain(`developers.${APEX}/`);
+  });
 });

--- a/web/src/components/marketing/site-chrome.tsx
+++ b/web/src/components/marketing/site-chrome.tsx
@@ -35,6 +35,12 @@ export function SiteNav() {
           <Link className="mk-navlink" href="/docs">
             Docs
           </Link>
+          {/* The path, not the host: on deployments with host-based sections
+              it redirects to developers.<domain>, and everywhere else (local
+              dev, apex-only installs) it serves the reference in place. */}
+          <Link className="mk-navlink" href="/api-reference">
+            Developers
+          </Link>
           <Link className="mk-navlink" href="/faq">
             FAQ
           </Link>
@@ -86,6 +92,7 @@ const FOOTER_TOPICS = [
 
 const FOOTER_SITE = [
   { label: "Documentation", href: "/docs" },
+  { label: "API reference", href: "/api-reference" },
   { label: "Community", href: "/community" },
   { label: "Forum", href: "/forum" },
   { label: "Glossary", href: "/glossary" },


### PR DESCRIPTION
Adds Developers to the site nav (and API reference to the footer), pointing at /api-reference so it redirects to developers.<domain> where subdomains are enabled and serves in place everywhere else. e2e covers the click-through and the host canonicalization; make verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)