### PR TITLE
feat(api)!: public API ok/data/error envelope

### DIFF
--- a/back/app/api/public/app.py
+++ b/back/app/api/public/app.py
@@ -17,11 +17,9 @@ routes — different prefix, different job.
 
 from typing import Any
 
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
-from starlette.exceptions import HTTPException as StarletteHTTPException
+from fastapi import FastAPI
 
-from app.api.exceptions import register_exception_handlers
+from app.api.public.errors import register_public_exception_handlers
 from app.api.public.routers import ai, attachments, graph, links, notes, search, tags, vaults
 from app.api.public.schemas import ErrorResponse
 from app.settings import get_settings
@@ -48,12 +46,18 @@ curl -H "Authorization: Bearer $NODUM_KEY" \\
   https://your-nodum/api/public/v1/vaults
 ```
 
+```json
+{ "ok": true, "data": [ { "id": "…", "name": "Second Brain" } ] }
+```
+
 Take a vault `id` from the answer, then search it, read a note, create one.
 
 ## Conventions
 
-- Success is `{"data": ...}`; every error is `{"error": {"code", "message"}}`
-  with a stable `code` (`not_found`, `forbidden`, `conflict`, …).
+- Success is `{"ok": true, "data": ...}`; every error is
+  `{"ok": false, "error": {"code", "details", "message"}}` with a stable
+  SCREAMING_SNAKE `code` (`NOT_FOUND`, `FORBIDDEN`, `CONFLICT`, …) and
+  `details` carrying the specifics.
 - Anything of yours that does not exist — and anything that is not yours —
   is the same `404`.
 - Note lists and search take `limit` + `offset` and return `total`; capped
@@ -83,14 +87,7 @@ def create_public_app() -> FastAPI:
         swagger_ui_parameters={"persistAuthorization": True},
         # No lifespan: it would never fire under a mount (see app/main.py).
     )
-    register_exception_handlers(app)
-
-    # Starlette's own 404 (unknown path) and 405 (wrong method) bypass the
-    # NodumError handlers and would answer {"detail": ...} — keep the envelope.
-    @app.exception_handler(StarletteHTTPException)
-    async def _plain_http_error(request: Request, exc: StarletteHTTPException) -> JSONResponse:
-        code = {404: "not_found", 405: "method_not_allowed"}.get(exc.status_code, f"http_{exc.status_code}")
-        return JSONResponse(status_code=exc.status_code, content={"error": {"code": code, "message": str(exc.detail)}})
+    register_public_exception_handlers(app)
 
     app.include_router(vaults.router, prefix="/vaults", tags=["Vaults"], responses={**_ERRORS, **_FORBIDDEN})
     app.include_router(

--- a/back/app/api/public/errors.py
+++ b/back/app/api/public/errors.py
@@ -1,0 +1,94 @@
+"""The public API's error envelope.
+
+Every failure answers with the same three fields, whatever raised it:
+
+    {"ok": false, "error": {"code", "details", "message"}}
+
+`code` is SCREAMING_SNAKE and stable — clients branch on it. `message` is
+the short human line. `details` carries the specifics (which field, which
+scope, what conflicted) and falls back to `message` when there are none, so
+the shape never changes shape under a client.
+"""
+
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.core.custom_exceptions import NodumError
+from app.core.logging import get_logger
+
+logger = get_logger("public_api")
+
+# Starlette raises these itself, before any of our code runs.
+_HTTP_CODES: dict[int, str] = {
+    404: "NOT_FOUND",
+    405: "METHOD_NOT_ALLOWED",
+    406: "NOT_ACCEPTABLE",
+    413: "PAYLOAD_TOO_LARGE",
+    429: "RATE_LIMITED",
+}
+
+
+PUBLIC_API_PREFIX = "/api/public/"
+
+
+def error_body(code: str, message: str, details: str | None = None) -> dict[str, Any]:
+    """The one place the public error envelope is built."""
+    return {"ok": False, "error": {"code": code, "details": details or message, "message": message}}
+
+
+def envelope_for(path: str, code: str, message: str, details: str | None = None) -> dict[str, Any]:
+    """The right error envelope for whichever API the request was aimed at.
+
+    Middleware runs before the mount, so a 429 or a 413 on a public path must
+    still speak the public dialect — a client parsing `ok` should never meet
+    the app API's shape.
+    """
+    if path.startswith(PUBLIC_API_PREFIX):
+        return error_body(code, message, details)
+    return {"error": {"code": code.lower(), "message": message}}
+
+
+def _details_from(exc: NodumError) -> str | None:
+    """A NodumError's structured extras, flattened into one readable line."""
+    if not exc.details:
+        return None
+    return "; ".join(f"{k}={v}" for k, v in exc.details.items())
+
+
+def _details_from_validation(exc: RequestValidationError) -> str:
+    """`body.title: Field required; query.limit: Input should be <= 200`."""
+    parts: list[str] = []
+    for err in exc.errors():
+        where = ".".join(str(p) for p in err.get("loc", ()) if p != "body" or len(err.get("loc", ())) == 1)
+        parts.append(f"{where}: {err.get('msg', 'invalid')}" if where else str(err.get("msg", "invalid")))
+    return "; ".join(parts) or "Request validation failed."
+
+
+def register_public_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(NodumError)
+    async def _nodum_error(request: Request, exc: NodumError) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=error_body(exc.code.upper(), exc.message, _details_from(exc)),
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_error(request: Request, exc: RequestValidationError) -> JSONResponse:
+        return JSONResponse(
+            status_code=422,
+            content=error_body("VALIDATION_FAILED", "Request validation failed.", _details_from_validation(exc)),
+        )
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _http_error(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+        code = _HTTP_CODES.get(exc.status_code, f"HTTP_{exc.status_code}")
+        return JSONResponse(status_code=exc.status_code, content=error_body(code, str(exc.detail)))
+
+    @app.exception_handler(Exception)
+    async def _unhandled(request: Request, exc: Exception) -> JSONResponse:
+        logger.exception("public_api_unhandled", path=request.url.path)
+        return JSONResponse(status_code=500, content=error_body("INTERNAL_ERROR", "Internal server error."))

--- a/back/app/api/public/routers/ai.py
+++ b/back/app/api/public/routers/ai.py
@@ -28,4 +28,4 @@ async def ask(vault_id: UUID, body: AiAsk, user_id: AiUser, db: SessionDep) -> A
             db, user_id, vault_id, message=body.message, conversation_id=body.conversation_id, context=body.context
         )
     ).unwrap()
-    return {"data": result}
+    return {"ok": True, "data": result}

--- a/back/app/api/public/routers/attachments.py
+++ b/back/app/api/public/routers/attachments.py
@@ -17,7 +17,7 @@ router = APIRouter()
 
 @router.get("", summary="List attachments", response_model=Envelope[list[AttachmentOut]])
 async def list_attachments(vault_id: UUID, user_id: ReadUser, db: SessionDep) -> Any:
-    return {"data": (await attachment_service.list_attachments(db, vault_id, user_id)).unwrap()}
+    return {"ok": True, "data": (await attachment_service.list_attachments(db, vault_id, user_id)).unwrap()}
 
 
 @router.post(
@@ -42,16 +42,16 @@ async def upload_attachment(vault_id: UUID, file: UploadFile, user_id: WriteUser
             mime_type=file.content_type or "application/octet-stream",
         )
     ).unwrap()
-    return {"data": attachment}
+    return {"ok": True, "data": attachment}
 
 
 @router.get("/{attachment_id}/url", summary="Download URL", response_model=Envelope[PresignedUrlData])
 async def presigned_url(vault_id: UUID, attachment_id: UUID, user_id: ReadUser, db: SessionDep) -> Any:
     """A time-limited URL to fetch the file's bytes from."""
-    return {"data": (await attachment_service.presigned_url(db, vault_id, user_id, attachment_id)).unwrap()}
+    return {"ok": True, "data": (await attachment_service.presigned_url(db, vault_id, user_id, attachment_id)).unwrap()}
 
 
 @router.delete("/{attachment_id}", summary="Delete an attachment")
 async def delete_attachment(vault_id: UUID, attachment_id: UUID, user_id: DeleteUser, db: SessionDep) -> dict[str, Any]:
     (await attachment_service.delete_attachment(db, vault_id, user_id, attachment_id)).unwrap()
-    return {"data": {"deleted": str(attachment_id)}}
+    return {"ok": True, "data": {"deleted": str(attachment_id)}}

--- a/back/app/api/public/routers/graph.py
+++ b/back/app/api/public/routers/graph.py
@@ -15,7 +15,7 @@ router = APIRouter()
 @router.get("/graph", summary="Whole-vault graph")
 async def get_graph(vault_id: UUID, user_id: ReadUser, db: SessionDep) -> dict[str, Any]:
     """Nodes (notes, plus unresolved `ghost:` targets) and edges as node-index pairs."""
-    return {"data": (await link_service.get_graph(db, vault_id, user_id)).unwrap()}
+    return {"ok": True, "data": (await link_service.get_graph(db, vault_id, user_id)).unwrap()}
 
 
 @router.get("/notes/{note_id}/graph", summary="Local graph around a note")
@@ -26,4 +26,7 @@ async def get_local_graph(
     db: SessionDep,
     depth: int = Query(default=1, ge=1, le=5, description="How many hops out from the note."),
 ) -> dict[str, Any]:
-    return {"data": (await link_service.get_local_graph(db, vault_id, user_id, note_id, depth=depth)).unwrap()}
+    return {
+        "ok": True,
+        "data": (await link_service.get_local_graph(db, vault_id, user_id, note_id, depth=depth)).unwrap(),
+    }

--- a/back/app/api/public/routers/links.py
+++ b/back/app/api/public/routers/links.py
@@ -52,19 +52,22 @@ async def unlink_notes(
     an embed keeps counting as a link until it is edited out. `removed: 0`
     still succeeds (already unlinked).
     """
-    return {"data": (await link_service.unlink_notes(db, vault_id, user_id, note_id, target=target)).unwrap()}
+    return {
+        "ok": True,
+        "data": (await link_service.unlink_notes(db, vault_id, user_id, note_id, target=target)).unwrap(),
+    }
 
 
 @router.get("/{note_id}/links", summary="Outgoing links")
 async def get_outgoing_links(vault_id: UUID, note_id: UUID, user_id: ReadUser, db: SessionDep) -> dict[str, Any]:
     """Links FROM this note — resolved (with target id/path) and unresolved."""
-    return {"data": (await link_service.get_outgoing_links(db, vault_id, user_id, note_id)).unwrap()}
+    return {"ok": True, "data": (await link_service.get_outgoing_links(db, vault_id, user_id, note_id)).unwrap()}
 
 
 @router.get("/{note_id}/backlinks", summary="Backlinks")
 async def get_backlinks(vault_id: UUID, note_id: UUID, user_id: ReadUser, db: SessionDep) -> dict[str, Any]:
     """Notes that link TO this note, with the sentence around each link."""
-    return {"data": (await link_service.get_backlinks(db, vault_id, user_id, note_id)).unwrap()}
+    return {"ok": True, "data": (await link_service.get_backlinks(db, vault_id, user_id, note_id)).unwrap()}
 
 
 @router.get("/{note_id}/unlinked-mentions", summary="Unlinked mentions")
@@ -76,4 +79,7 @@ async def get_unlinked_mentions(
     limit: int = Query(default=20, ge=1, le=50),
 ) -> dict[str, Any]:
     """Notes whose text mentions this note's title without linking to it."""
-    return {"data": (await link_service.get_unlinked_mentions(db, vault_id, user_id, note_id, limit=limit)).unwrap()}
+    return {
+        "ok": True,
+        "data": (await link_service.get_unlinked_mentions(db, vault_id, user_id, note_id, limit=limit)).unwrap(),
+    }

--- a/back/app/api/public/routers/notes.py
+++ b/back/app/api/public/routers/notes.py
@@ -50,7 +50,7 @@ async def create_note(vault_id: UUID, body: NoteCreate, user_id: WriteUser, db: 
             db, vault_id, user_id, title=body.title, folder_id=folder_id, content=body.content
         )
     ).unwrap()
-    return {"data": note}
+    return {"ok": True, "data": note}
 
 
 @router.get("/by-path", summary="Read a note by path", response_model=Envelope[NoteOut])
@@ -60,13 +60,13 @@ async def get_note_by_path(
     db: SessionDep,
     path: str = Query(min_length=1, description='The note\'s full path, e.g. "Projects/Alpha".'),
 ) -> Any:
-    return {"data": (await note_service.get_note_by_path(db, vault_id, user_id, path)).unwrap()}
+    return {"ok": True, "data": (await note_service.get_note_by_path(db, vault_id, user_id, path)).unwrap()}
 
 
 @router.get("/{note_id}", summary="Read a note", response_model=Envelope[NoteOut])
 async def get_note(vault_id: UUID, note_id: UUID, user_id: ReadUser, db: SessionDep) -> Any:
     """The full note: markdown content, path, tags and other frontmatter properties."""
-    return {"data": (await note_service.get_note(db, vault_id, user_id, note_id)).unwrap()}
+    return {"ok": True, "data": (await note_service.get_note(db, vault_id, user_id, note_id)).unwrap()}
 
 
 @router.put("/{note_id}/content", summary="Write a note's body", response_model=Envelope[NoteWriteOut])
@@ -92,7 +92,7 @@ async def update_content(
             mode=body.mode,
         )
     ).unwrap()
-    return {"data": note}
+    return {"ok": True, "data": note}
 
 
 @router.patch("/{note_id}", summary="Rename or move a note", response_model=Envelope[NoteWriteOut])
@@ -111,7 +111,7 @@ async def move_note(vault_id: UUID, note_id: UUID, body: NoteMove, user_id: Writ
             db, vault_id, user_id, note_id, title=body.title, folder_id=folder_id, move_to_root=move_to_root
         )
     ).unwrap()
-    return {"data": note}
+    return {"ok": True, "data": note}
 
 
 @router.post("/{note_id}/tags", summary="Add or remove tags", response_model=Envelope[NoteWriteOut])
@@ -120,11 +120,11 @@ async def set_tags(vault_id: UUID, note_id: UUID, body: NoteTagsUpdate, user_id:
     note = (
         await note_service.set_tags(db, vault_id, user_id, note_id, add=body.add or None, remove=body.remove or None)
     ).unwrap()
-    return {"data": note}
+    return {"ok": True, "data": note}
 
 
 @router.delete("/{note_id}", summary="Delete a note")
 async def delete_note(vault_id: UUID, note_id: UUID, user_id: DeleteUser, db: SessionDep) -> dict[str, Any]:
     """Deletes the note. Links pointing at it become unresolved (ghosts in the graph)."""
     (await note_service.delete_note(db, vault_id, user_id, note_id)).unwrap()
-    return {"data": {"deleted": str(note_id)}}
+    return {"ok": True, "data": {"deleted": str(note_id)}}

--- a/back/app/api/public/routers/search.py
+++ b/back/app/api/public/routers/search.py
@@ -43,4 +43,4 @@ async def quick_switch(
     limit: int = Query(default=10, ge=1, le=25),
 ) -> Any:
     """What the in-app Cmd+O switcher uses — cheap fuzzy matching on titles and aliases."""
-    return {"data": (await search_service.quick_switch(db, vault_id, user_id, q=q, limit=limit)).unwrap()}
+    return {"ok": True, "data": (await search_service.quick_switch(db, vault_id, user_id, q=q, limit=limit)).unwrap()}

--- a/back/app/api/public/routers/tags.py
+++ b/back/app/api/public/routers/tags.py
@@ -16,11 +16,11 @@ router = APIRouter()
 @router.get("", summary="List tags", response_model=Envelope[list[TagOut]])
 async def list_tags(vault_id: UUID, user_id: ReadUser, db: SessionDep) -> Any:
     """Every tag in the vault with how many notes carry it."""
-    return {"data": (await tag_service.list_tags(db, vault_id, user_id)).unwrap()}
+    return {"ok": True, "data": (await tag_service.list_tags(db, vault_id, user_id)).unwrap()}
 
 
 @router.get("/{tag_name:path}", summary="Notes with a tag", response_model=Envelope[TagNotesData])
 async def notes_by_tag(vault_id: UUID, tag_name: str, user_id: ReadUser, db: SessionDep) -> Any:
     """Notes carrying `tag_name` (leading `#` optional). Nested tags match by prefix: `a` matches `a/b`."""
     notes = (await tag_service.notes_by_tag(db, vault_id, user_id, tag_name)).unwrap()
-    return {"data": {"name": tag_name.strip().lstrip("#").lower(), "notes": notes}}
+    return {"ok": True, "data": {"name": tag_name.strip().lstrip("#").lower(), "notes": notes}}

--- a/back/app/api/public/routers/vaults.py
+++ b/back/app/api/public/routers/vaults.py
@@ -16,7 +16,7 @@ router = APIRouter()
 @router.get("", summary="List vaults", response_model=Envelope[list[PublicVault]])
 async def list_vaults(user_id: ReadUser, db: SessionDep) -> Any:
     """Every vault the key's owner has. Almost every other call needs a `vault_id` from here."""
-    return {"data": (await vault_service.list_vaults(db, user_id)).unwrap()}
+    return {"ok": True, "data": (await vault_service.list_vaults(db, user_id)).unwrap()}
 
 
 @router.get("/{vault_id}/tree", summary="Folder & note tree")
@@ -25,4 +25,4 @@ async def get_tree(vault_id: UUID, user_id: ReadUser, db: SessionDep) -> dict[st
 
     Very large vaults set `truncated: true`; use *List notes* for the rest.
     """
-    return {"data": (await vault_service.get_tree(db, vault_id, user_id)).unwrap()}
+    return {"ok": True, "data": (await vault_service.get_tree(db, vault_id, user_id)).unwrap()}

--- a/back/app/api/public/schemas.py
+++ b/back/app/api/public/schemas.py
@@ -16,20 +16,31 @@ from app.schemas.vaults import NoteMetaOut, NoteOut
 
 
 class Envelope[T](BaseModel):
-    """Every success response: the payload under ``data``."""
+    """Every success response: `ok` plus the payload under `data`.
 
+    `ok` is redundant next to the HTTP status on purpose — clients that
+    funnel every call through one helper can branch on the body alone,
+    which is exactly what most SDK wrappers end up doing.
+    """
+
+    ok: bool = Field(default=True, description="Always `true` on a success response.")
     data: T
 
 
 class ErrorInfo(BaseModel):
-    code: str = Field(description="Stable machine-readable code, e.g. `not_found`, `forbidden`, `conflict`.")
-    message: str = Field(description="Human-readable explanation.")
-    details: dict[str, Any] | None = Field(default=None, description="Extra context on some errors.")
+    code: str = Field(
+        description="Stable machine-readable code in SCREAMING_SNAKE_CASE, e.g. `NOT_FOUND`, `FORBIDDEN`, `CONFLICT`."
+    )
+    details: str = Field(
+        description="The specifics: which field, which scope, what conflicted. Falls back to `message`."
+    )
+    message: str = Field(description="Short human-readable explanation.")
 
 
 class ErrorResponse(BaseModel):
-    """Every error response: `{\"error\": {\"code\", \"message\"}}`."""
+    """Every error response: `{"ok": false, "error": {"code", "details", "message"}}`."""
 
+    ok: bool = Field(default=False, description="Always `false` on an error response.")
     error: ErrorInfo
 
 

--- a/back/app/core/middlewares/body_size_middleware.py
+++ b/back/app/core/middlewares/body_size_middleware.py
@@ -31,14 +31,23 @@ class MaxBodySizeMiddleware(BaseHTTPMiddleware):
                 length = int(declared)
             except ValueError:
                 # A malformed Content-Length is not something to forward on.
+                from app.api.public.errors import envelope_for
+
                 return JSONResponse(
                     status_code=400,
-                    content={"error": {"code": "bad_request", "message": "Invalid Content-Length."}},
+                    content=envelope_for(request.url.path, "BAD_REQUEST", "Invalid Content-Length."),
                 )
             if length > MAX_REQUEST_BODY_BYTES:
                 logger.warning("request_body_too_large", declared=length, path=request.url.path)
+                from app.api.public.errors import envelope_for
+
                 return JSONResponse(
                     status_code=413,
-                    content={"error": {"code": "payload_too_large", "message": "Request body is too large."}},
+                    content=envelope_for(
+                        request.url.path,
+                        "PAYLOAD_TOO_LARGE",
+                        "Request body is too large.",
+                        f"{length} bytes declared; the limit is {MAX_REQUEST_BODY_BYTES}",
+                    ),
                 )
         return await call_next(request)

--- a/back/app/core/middlewares/rate_limit_middleware.py
+++ b/back/app/core/middlewares/rate_limit_middleware.py
@@ -122,9 +122,13 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 await redis_control.expire(key, window)
             if count > limit:
                 ttl = await redis_control.ttl(key)
+                from app.api.public.errors import envelope_for
+
                 return JSONResponse(
                     status_code=429,
-                    content={"error": {"code": "rate_limited", "message": "Too many requests."}},
+                    content=envelope_for(
+                        path, "RATE_LIMITED", "Too many requests.", f"retry after {max(ttl, 1)} seconds"
+                    ),
                     headers={"Retry-After": str(max(ttl, 1))},
                 )
         except Exception:  # Redis down — fail open

--- a/back/tests/integration/test_public_api.py
+++ b/back/tests/integration/test_public_api.py
@@ -48,7 +48,7 @@ async def test_only_an_api_key_authenticates(client: AsyncClient) -> None:
         headers = {"Authorization": f"Bearer {token}"} if token else {}
         resp = await client.get(f"{P}/vaults", headers=headers)
         assert resp.status_code == 401, (token, resp.text)
-        assert resp.json()["error"]["code"] == "unauthorized"
+        assert resp.json()["error"]["code"] == "UNAUTHORIZED"
 
     # …and the key does not work where the MCP token belongs.
     resp = await client.post(
@@ -158,7 +158,7 @@ async def test_note_crud_roundtrip(client: AsyncClient) -> None:
     assert note["path"] == "Projects/2026/Alpha"
 
     dup = await client.post(f"{P}/vaults/{v}/notes", json={"title": "Alpha", "folder": "Projects/2026"}, headers=h)
-    assert dup.status_code == 409 and dup.json()["error"]["code"] == "already_exists"
+    assert dup.status_code == 409 and dup.json()["error"]["code"] == "ALREADY_EXISTS"
 
     by_path = await client.get(f"{P}/vaults/{v}/notes/by-path", params={"path": "Projects/2026/Alpha"}, headers=h)
     assert by_path.status_code == 200 and by_path.json()["data"]["id"] == note["id"]
@@ -185,7 +185,7 @@ async def test_note_crud_roundtrip(client: AsyncClient) -> None:
     )
     assert stale.status_code == 409
     err = stale.json()["error"]
-    assert err["code"] == "conflict" and err["details"]["server_updated_at"]
+    assert err["code"] == "CONFLICT" and "server_updated_at=" in err["details"]
 
     moved = await client.patch(
         f"{P}/vaults/{v}/notes/{note['id']}", json={"title": "Alpha Two", "folder": "Archive"}, headers=h
@@ -360,9 +360,9 @@ async def test_openapi_is_public_and_only_public(client: AsyncClient) -> None:
 
     # Unknown paths and wrong methods keep the error envelope too.
     lost = await client.get(f"{P}/no/such/thing")
-    assert lost.status_code == 404 and lost.json()["error"]["code"] == "not_found"
+    assert lost.status_code == 404 and lost.json()["error"]["code"] == "NOT_FOUND"
     wrong = await client.delete(f"{P}/vaults")
-    assert wrong.status_code == 405 and wrong.json()["error"]["code"] == "method_not_allowed"
+    assert wrong.status_code == 405 and wrong.json()["error"]["code"] == "METHOD_NOT_ALLOWED"
 
 
 # ── The review's regressions, pinned ─────────────────────────────────────────
@@ -473,3 +473,68 @@ async def test_list_notes_total_is_honest_past_the_end(client: AsyncClient) -> N
         await client.get(f"{P}/vaults/{v}/notes", params={"folder": "Off", "limit": 2, "offset": 10}, headers=h)
     ).json()["data"]
     assert past["items"] == [] and past["total"] == 3
+
+
+async def test_every_response_speaks_the_public_envelope(client: AsyncClient) -> None:
+    """`{"ok": true, "data"}` on success, `{"ok": false, "error"}` on failure —
+    including the errors raised before the sub-app is reached."""
+    account = await _account(client, "envelope")
+    v, h = account["vault_id"], account["headers"]
+
+    listed = await client.get(f"{P}/vaults", headers=h)
+    body = listed.json()
+    assert body["ok"] is True and isinstance(body["data"], list)
+    assert set(body) == {"ok", "data"}, body.keys()
+
+    note = (await client.post(f"{P}/vaults/{v}/notes", json={"title": "Enveloped"}, headers=h)).json()
+    assert note["ok"] is True and note["data"]["title"] == "Enveloped"
+
+    # Routes with a response_model get `ok` from the schema default; these
+    # return a bare dict, so they prove the routers wrap it themselves.
+    for path in (f"/vaults/{v}/tree", f"/vaults/{v}/graph", f"/vaults/{v}/notes/{note['data']['id']}/backlinks"):
+        raw = (await client.get(f"{P}{path}", headers=h)).json()
+        assert raw["ok"] is True and "data" in raw, (path, raw.keys())
+        assert set(raw) == {"ok", "data"}, (path, raw.keys())
+
+    failures = [
+        (await client.get(f"{P}/vaults", headers={"Authorization": "Bearer nodum_key_nope"}), "UNAUTHORIZED"),
+        (await client.get(f"{P}/vaults/{v}/notes/{uuid.uuid4()}", headers=h), "NOT_FOUND"),
+        (await client.post(f"{P}/vaults/{v}/notes", json={"nope": 1}, headers=h), "VALIDATION_FAILED"),
+        (await client.get(f"{P}/no/such/route", headers=h), "NOT_FOUND"),
+        (await client.delete(f"{P}/vaults", headers=h), "METHOD_NOT_ALLOWED"),
+    ]
+    for resp, code in failures:
+        err = resp.json()
+        assert err["ok"] is False, err
+        assert set(err) == {"ok", "error"}, err.keys()
+        assert set(err["error"]) == {"code", "details", "message"}, err["error"].keys()
+        assert err["error"]["code"] == code, (resp.request.url, err)
+        assert isinstance(err["error"]["details"], str) and err["error"]["details"]
+        assert isinstance(err["error"]["message"], str) and err["error"]["message"]
+
+    # Validation details name the offending field rather than repeating the message.
+    bad = (await client.post(f"{P}/vaults/{v}/notes", json={}, headers=h)).json()
+    assert "title" in bad["error"]["details"], bad
+
+    # The app API is untouched: it keeps its own shape.
+    internal = await client.get("/api/v1/vaults", headers=account["session"])
+    assert "ok" not in internal.json() and "data" in internal.json()
+    missing = await client.get(f"/api/v1/vaults/{v}/notes/{uuid.uuid4()}", headers=account["session"])
+    assert missing.status_code == 404
+    assert missing.json()["error"]["code"] == "not_found" and "ok" not in missing.json()
+
+
+async def test_middleware_errors_keep_the_public_envelope(client: AsyncClient) -> None:
+    """A 429 or 413 is produced before the mount — it must not leak the app
+    API's dialect into a public response."""
+    from app.api.public.errors import envelope_for
+
+    public = envelope_for("/api/public/v1/vaults", "RATE_LIMITED", "Too many requests.", "retry after 30 seconds")
+    assert public["ok"] is False
+    assert public["error"] == {
+        "code": "RATE_LIMITED",
+        "details": "retry after 30 seconds",
+        "message": "Too many requests.",
+    }
+    internal = envelope_for("/api/v1/vaults", "RATE_LIMITED", "Too many requests.")
+    assert "ok" not in internal and internal["error"]["code"] == "rate_limited"

--- a/deploy/smoke.sh
+++ b/deploy/smoke.sh
@@ -124,7 +124,14 @@ k=$(curl -s -X POST "$BASE/api/v1/api-keys" -H "$AUTH" -H 'Content-Type: applica
 KEY=$(printf '%s' "$k" | python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["token"])' 2>/dev/null)
 if [ -n "$KEY" ]; then
   pv=$(curl -s "$BASE/api/public/v1/vaults" -H "Authorization: Bearer $KEY")
-  echo "$pv" | grep -q '"data"' && ok "public API answers a scoped key" || bad "public API failed: ${pv:0:160}"
+  echo "$pv" | grep -q '"ok":true' && ok "public API answers a scoped key" || bad "public API failed: ${pv:0:160}"
+  # The header goes through a variable like every other call here: an inline
+  # "Authorization: Bearer …" literal trips the repo's secret scanner even
+  # when the value is deliberately bogus.
+  BAD_AUTH="Authorization: Bearer nodum_key_${RANDOM}_not_a_real_key"
+  pe=$(curl -s "$BASE/api/public/v1/vaults" -H "$BAD_AUTH")
+  echo "$pe" | grep -q '"ok":false' && echo "$pe" | grep -q "UNAUTHORIZED" \
+    && ok "public API errors use the ok/error envelope" || bad "public API error shape: ${pe:0:160}"
   KID=$(printf '%s' "$k" | python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["id"])')
   curl -s -X DELETE "$BASE/api/v1/api-keys/$KID" -H "$AUTH" > /dev/null
 else

--- a/web/src/content/docs/api-notes.md
+++ b/web/src/content/docs/api-notes.md
@@ -14,9 +14,9 @@ KEY="nodum_key_…"        # Settings → API keys
 ```
 
 and sends the key the same way every time: `-H "Authorization: Bearer $KEY"`.
-Success is always `{"data": ...}`; errors are always
-`{"error": {"code", "message"}}`. **Writes return metadata, never bodies** —
-reading content back needs the `read` scope.
+Success is always `{"ok": true, "data": ...}`; errors are always
+`{"ok": false, "error": {"code", "details", "message"}}`. **Writes return
+metadata, never bodies** — reading content back needs the `read` scope.
 
 ## Find your vault
 
@@ -25,7 +25,8 @@ curl -H "Authorization: Bearer $KEY" $NODUM/vaults
 ```
 
 ```json
-{ "data": [ { "id": "0198…", "name": "Second Brain",
+{ "ok": true,
+  "data": [ { "id": "0198…", "name": "Second Brain",
               "created_at": "2026-08-01T09:00:00Z", "updated_at": "2026-08-21T07:00:00Z" } ] }
 ```
 
@@ -42,7 +43,8 @@ curl -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
 ```
 
 ```json
-{ "data": { "id": "0198…", "folder_id": "0198…", "title": "Standup 21 Aug",
+{ "ok": true,
+  "data": { "id": "0198…", "folder_id": "0198…", "title": "Standup 21 Aug",
             "path": "Work/Standups/Standup 21 Aug",
             "created_at": "…", "updated_at": "…" } }
 ```
@@ -62,7 +64,7 @@ plus the metadata above. `by-path` takes the exact path
 first, `total` for pagination:
 
 ```json
-{ "data": { "items": [ … ], "total": 128, "limit": 50, "offset": 0 } }
+{ "ok": true, "data": { "items": [ … ], "total": 128, "limit": 50, "offset": 0 } }
 ```
 
 ## Edit safely — `PUT /vaults/{id}/notes/{note_id}/content` *(write)*
@@ -110,12 +112,15 @@ Links pointing at the deleted note become unresolved ghosts in the graph.
 
 ## The errors you will actually see
 
+Errors carry `code` (branch on this), `message` (show this) and `details`
+(the specifics — which field, which scope, what conflicted):
+
 | Code | Meaning |
 | --- | --- |
-| `unauthorized` (401) | Missing, mistyped or revoked key — or a password change revoked it. |
-| `forbidden` (403) | The key lacks the scope; the message names which one. |
-| `not_found` (404) | Not there — or not yours. Deliberately the same answer. |
-| `already_exists` (409) | A note at that path already exists. |
-| `conflict` (409) | Stale `base_updated_at`; `details.server_updated_at` says what won. |
-| `validation_failed` (422) | Bad input; the message says what. |
-| `rate_limited` (429) | Slow down — 300 requests/minute per key by default. |
+| `UNAUTHORIZED` (401) | Missing, mistyped or revoked key — or a password change revoked it. |
+| `FORBIDDEN` (403) | The key lacks the scope; `details` names which one. |
+| `NOT_FOUND` (404) | Not there — or not yours. Deliberately the same answer. |
+| `ALREADY_EXISTS` (409) | A note at that path already exists. |
+| `CONFLICT` (409) | Stale `base_updated_at`; `details` carries `server_updated_at=…`. |
+| `VALIDATION_FAILED` (422) | Bad input; `details` names the field. |
+| `RATE_LIMITED` (429) | Slow down — 300 requests/minute per key by default. |

--- a/web/src/content/docs/api-recipes.md
+++ b/web/src/content/docs/api-recipes.md
@@ -93,7 +93,7 @@ const api = async (method, path, body) => {
     body: body && JSON.stringify(body),
   });
   const j = await r.json();
-  if (!r.ok) throw new Error(j.error.message);
+  if (!j.ok) throw new Error(`${j.error.code}: ${j.error.details}`);
   return j.data;
 };
 
@@ -109,8 +109,11 @@ for (const m of unlinked_mentions ?? []) {
 
 - **One key per program**, named after it, with only the scopes it needs —
   revoking one never breaks the others.
-- **Treat 409 as information**: `already_exists` means create-once logic can
-  be a plain retry; `conflict` means re-read, merge, re-send.
+- **Branch on the body, not just the status**: every response carries `ok`,
+  so one helper (`if (!body.ok) throw new Error(body.error.message)`) covers
+  every call.
+- **Treat 409 as information**: `ALREADY_EXISTS` means create-once logic can
+  be a plain retry; `CONFLICT` means re-read, merge, re-send.
 - **Remember the password rule**: changing or resetting the account password
   revokes every key. Cron jobs fail with `401` — mint fresh keys after.
 - The [interactive reference](/api-reference) shows every endpoint with

--- a/web/src/content/docs/api-search-links.md
+++ b/web/src/content/docs/api-search-links.md
@@ -18,7 +18,7 @@ curl -H "Authorization: Bearer $KEY" \
 ```
 
 ```json
-{ "data": { "query": "spaced repetition", "total": 7,
+{ "ok": true, "data": { "query": "spaced repetition", "total": 7,
   "results": [ { "id": "0198…", "title": "Learning", "path": "Topics/Learning",
                  "snippet": "…the case for <mark>spaced</mark> <mark>repetition</mark>…",
                  "rank": 0.61, "created_at": "…", "updated_at": "…" } ] } }
@@ -44,7 +44,7 @@ curl -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
 ```
 
 ```json
-{ "data": { "from": "0198…", "to": "0198…",
+{ "ok": true, "data": { "from": "0198…", "to": "0198…",
             "inserted": "- [[Learning]]", "already_linked": false } }
 ```
 

--- a/web/src/content/docs/api.md
+++ b/web/src/content/docs/api.md
@@ -53,8 +53,22 @@ curl -H "Authorization: Bearer nodum_key_…" -H "Content-Type: application/json
   https://your-nodum/api/public/v1/vaults/<vault_id>/notes
 ```
 
-Every success is `{"data": ...}`; every error is
-`{"error": {"code", "message"}}` with a stable `code`.
+Every success is `{"ok": true, "data": ...}`:
+
+```json
+{ "ok": true, "data": { "id": "0198…", "title": "From the API", "path": "Inbox/From the API" } }
+```
+
+Every error is `{"ok": false, "error": {...}}` with a stable
+SCREAMING_SNAKE `code`, a short `message`, and `details` carrying the
+specifics:
+
+```json
+{ "ok": false, "error": {
+    "code": "VALIDATION_FAILED",
+    "details": "body.title: Field required",
+    "message": "Request validation failed." } }
+```
 
 ## Scopes
 


### PR DESCRIPTION
External responses become `{"ok": true, "data": …}` and `{"ok": false, "error": {"code", "details", "message"}}` with SCREAMING_SNAKE codes; middleware-produced 429/413 speak the same dialect; /api/v1 (the web client's API) is untouched and pinned by a test. 196 backend integration tests + 8 e2e green; make verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)